### PR TITLE
Make arrays available in Python as np.ndarray objects

### DIFF
--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -1,0 +1,2 @@
+find_package(Python3 REQUIRED
+             COMPONENTS Development NumPy)

--- a/cmake/SetupTPL.cmake
+++ b/cmake/SetupTPL.cmake
@@ -120,6 +120,27 @@ if(ENABLE_CALIPER)
     set(thirdPartyLibs ${thirdPartyLibs} caliper)
 endif()
 
+################################
+# Python
+################################
+if(ENABLE_PYTHON)
+    include(cmake/FindPython.cmake)
+    message(STATUS "Using Python Include: ${PYTHON_INCLUDE_DIRS}")
+    # include_directories(${PYTHON_INCLUDE_DIRS})
+    # # if we don't find python, throw a fatal error
+    # if(NOT PYTHON_FOUND)
+    #     message(FATAL_ERROR "ENABLE_PYTHON is true, but Python wasn't found.")
+    # endif()
+
+    # include(cmake/thirdparty/FindNumPy.cmake)
+    # message(STATUS "Using NumPy Include: ${NUMPY_INCLUDE_DIRS}")
+    # include_directories(${NUMPY_INCLUDE_DIRS})
+    # # if we don't find numpy, throw a fatal error
+    # if(NOT NUMPY_FOUND)
+    #     message(FATAL_ERROR "ENABLE_PYTHON is true, but NumPy wasn't found.")
+    # endif()
+endif()
+
 
 
 

--- a/cmake/SetupTPL.cmake
+++ b/cmake/SetupTPL.cmake
@@ -126,19 +126,6 @@ endif()
 if(ENABLE_PYTHON)
     include(cmake/FindPython.cmake)
     message(STATUS "Using Python Include: ${PYTHON_INCLUDE_DIRS}")
-    # include_directories(${PYTHON_INCLUDE_DIRS})
-    # # if we don't find python, throw a fatal error
-    # if(NOT PYTHON_FOUND)
-    #     message(FATAL_ERROR "ENABLE_PYTHON is true, but Python wasn't found.")
-    # endif()
-
-    # include(cmake/thirdparty/FindNumPy.cmake)
-    # message(STATUS "Using NumPy Include: ${NUMPY_INCLUDE_DIRS}")
-    # include_directories(${NUMPY_INCLUDE_DIRS})
-    # # if we don't find numpy, throw a fatal error
-    # if(NOT NUMPY_FOUND)
-    #     message(FATAL_ERROR "ENABLE_PYTHON is true, but NumPy wasn't found.")
-    # endif()
 endif()
 
 

--- a/host-configs/LLNL/quartz-base.cmake
+++ b/host-configs/LLNL/quartz-base.cmake
@@ -28,6 +28,9 @@ set(GEOSX_TPL_DIR ${GEOSX_TPL_ROOT_DIR}/2020-07-08/install-${CONFIG_NAME}-releas
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 set(ENABLE_CHAI ON CACHE BOOL "")
 
+set(ENABLE_PYTHON ON CACHE BOOL "")
+set(PYTHON_DIR /usr/tce/packages/python/python-3.7.2 CACHE PATH "")
+
 set(SPHINX_EXECUTABLE /collab/usr/gapps/python/build/spack-toss3.2/opt/spack/linux-rhel7-x86_64/gcc-4.9.3/python-2.7.14-7rci3jkmuht2uiwp433afigveuf4ocnu/bin/sphinx-build CACHE PATH "")
 set(DOXYGEN_EXECUTABLE ${GEOSX_TPL_ROOT_DIR}/doxygen/bin/doxygen CACHE PATH "")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,10 +45,10 @@ set(lvarray_sources
     )
 
 if(ENABLE_PYTHON)
-    set(lvarray_headers
-        python/numpyConversion.hpp
-        python/numpyArrayView.hpp
-        python/numpySortedArrayView.hpp
+    list( APPEND lvarray_headers
+          python/numpyConversion.hpp
+          python/numpyArrayView.hpp
+          python/numpySortedArrayView.hpp
         )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_subdirectory(docs)
 
-    
-        set(lvarray_headers
+set(lvarray_headers
     templateHelpers.hpp
     Array.hpp
     ArraySlice.hpp
@@ -45,6 +44,13 @@ set(lvarray_sources
     totalview/tv_data_display.c 
     )
 
+if(ENABLE_PYTHON)
+    set(lvarray_headers
+        python/numpyConversion.hpp
+        python/numpyArrayView.hpp
+        python/numpySortedArrayView.hpp
+        )
+endif()
 
 message("adding lvarray library")
 blt_add_library( NAME             lvarray
@@ -57,4 +63,3 @@ target_include_directories( lvarray PUBLIC ${CMAKE_BINARY_DIR}/include )
 
 lvarray_add_code_checks( PREFIX lvarray
                          EXCLUDES "blt/*" )
-

--- a/src/python/numpyArrayView.hpp
+++ b/src/python/numpyArrayView.hpp
@@ -1,0 +1,46 @@
+/*
+ *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory
+ *
+ * LLNL-CODE-746361
+ *
+ * All rights reserved. See COPYRIGHT for details.
+ *
+ * This file is part of the GEOSX Simulation Framework.
+ *
+ * GEOSX is a free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (as published by the
+ * Free Software Foundation) version 2.1 dated February 1999.
+ *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+
+/**
+ * @file numpyArrayView.hpp
+ */
+
+#pragma once
+#include "numpyConversion.hpp"
+#include "../ArrayView.hpp"
+
+namespace LvArray
+{
+
+namespace python
+{
+
+/**
+ * Return a Numpy view of an Array
+ * @param arr the ArrayView to convert to numpy.
+ */
+template< typename T, int NDIM, int USD, typename INDEX_TYPE, template<typename> class BUFFER_TYPE >
+PyObject * create( ArrayView<T, NDIM, USD, INDEX_TYPE, BUFFER_TYPE > const & arr )
+{
+    arr.move( MemorySpace::CPU );
+    return internal::create( arr.data(), NDIM, arr.dims(), arr.strides() );
+}
+
+} // namespace python
+
+} // namespace LvArray

--- a/src/python/numpyArrayView.hpp
+++ b/src/python/numpyArrayView.hpp
@@ -21,6 +21,8 @@
  */
 
 #pragma once
+
+// source includes
 #include "numpyConversion.hpp"
 #include "../ArrayView.hpp"
 
@@ -31,7 +33,16 @@ namespace python
 {
 
 /**
- * Return a Numpy view of an Array
+ * @brief Return a Numpy view of an ArrayView. This numpy view may not be resized. If T is const,
+ *        the contents may not be modified. The numpy view will be invalidated if the array is
+ *        reallocated.
+ * @tparam T type of data that is contained by the array.
+ * @tparam NDIM number of dimensions in array
+ * @tparam PERMUTATION a camp::idx_seq containing the values in [0, NDIM) which describes how the
+ *         data is to be laid out in memory.
+ * @tparam INDEX_TYPE the integer to use for indexing.
+ * @tparam BUFFER_TYPE A class that defines how to actually allocate memory for the Array. Must take
+ *         one template argument that describes the type of the data being stored (T).
  * @param arr the ArrayView to convert to numpy.
  */
 template< typename T, int NDIM, int USD, typename INDEX_TYPE, template<typename> class BUFFER_TYPE >

--- a/src/python/numpyConversion.hpp
+++ b/src/python/numpyConversion.hpp
@@ -1,0 +1,119 @@
+/*
+ *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory
+ *
+ * LLNL-CODE-746361
+ *
+ * All rights reserved. See COPYRIGHT for details.
+ *
+ * This file is part of the GEOSX Simulation Framework.
+ *
+ * GEOSX is a free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (as published by the
+ * Free Software Foundation) version 2.1 dated February 1999.
+ *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+
+/**
+ * @file numpyConversion.hpp
+ */
+
+#pragma once
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_15_API_VERSION
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL LvArray_ARRAY_API
+
+#include <Python.h>
+#include <numpy/arrayobject.h>
+
+#include "../StringUtilities.hpp"
+#include "../IntegerConversion.hpp"
+
+#include <typeindex>
+#include <type_traits>
+
+namespace LvArray
+{
+
+namespace python
+{
+
+namespace internal
+{
+
+/**
+ * @brief Get the Numpy type-flag corresponding to a `std::type_info` object.
+ * @param tid the type_info object to use
+ */
+int getFlags( const std::type_info& tid ){
+    if ( std::type_index( tid ) == std::type_index( typeid( char ) ) )
+        return NPY_BYTE;
+    else if ( std::type_index( tid ) == std::type_index( typeid( short ) ) )
+        return NPY_SHORT;
+    else if ( std::type_index( tid ) == std::type_index( typeid( int ) ) )
+        return NPY_INT;
+    else if ( std::type_index( tid ) == std::type_index( typeid( unsigned int ) ) )
+        return NPY_UINT;
+    else if ( std::type_index( tid ) == std::type_index( typeid( long ) ) )
+        return NPY_LONG;
+    else if ( std::type_index( tid ) == std::type_index( typeid( long ) ) )
+        return NPY_ULONG;
+    else if ( std::type_index( tid ) == std::type_index( typeid( long long ) ) )
+        return NPY_LONGLONG;
+    else if ( std::type_index( tid ) == std::type_index( typeid( long long ) ) )
+        return NPY_ULONGLONG;
+    else if ( std::type_index( tid ) == std::type_index( typeid( float ) ) )
+        return NPY_FLOAT;
+    else if ( std::type_index( tid ) == std::type_index( typeid( double ) ) )
+        return NPY_DOUBLE;
+    else if ( std::type_index( tid ) == std::type_index( typeid( long double ) ) )
+        return NPY_LONGDOUBLE;
+    else {
+        LVARRAY_ERROR( "Unsupported type: " << demangle( tid.name() ) );
+        return -1;
+    }
+}
+
+/**
+ * @brief Create a numpy ndarray representing the given array. If T is const then the array should be immutable.
+ * @param data a pointer to the array.
+ * @param ndim the number of dimensions in the array.
+ * @param dims the number of elements in each dimension.
+ * @param strides the element-wise strides to reach the next element in each dimension.
+ */
+template< typename T, typename INDEX_TYPE >
+PyObject * create( T * const data, int ndim, INDEX_TYPE const * const dims, INDEX_TYPE const * const strides )
+{
+    using nonconstType = std::remove_const_t< T >;
+    int flags = 0;
+    std::vector<npy_intp> byteStrides( ndim );
+    std::vector<npy_intp> npyDims( ndim );
+    nonconstType * npyData = const_cast< nonconstType* >( data );
+    if ( !std::is_const< T >::value ){
+        flags = NPY_ARRAY_WRITEABLE;
+    }
+    for ( int i = 0; i < ndim; ++i )
+    {
+        byteStrides[ i ] = integerConversion< npy_intp >( strides[ i ] * sizeof( T ) );
+        npyDims[ i ] = integerConversion< npy_intp >( dims[ i ] );
+    }
+    return PyArray_NewFromDescr(
+        &PyArray_Type,
+        PyArray_DescrFromType( getFlags( typeid( T ) ) ),
+        ndim,
+        npyDims.data(),
+        byteStrides.data(),
+        npyData,
+        flags,
+        NULL
+    );
+}
+
+} // namespace internal
+
+} // namespace python
+
+} // namespace LvArray

--- a/src/python/numpyConversion.hpp
+++ b/src/python/numpyConversion.hpp
@@ -26,14 +26,18 @@
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL LvArray_ARRAY_API
 
-#include <Python.h>
-#include <numpy/arrayobject.h>
-
+// source includes
 #include "../StringUtilities.hpp"
 #include "../IntegerConversion.hpp"
 
+// TPL includes (note python.h must be included before any stdlib headers)
+#include <Python.h>
+#include <numpy/arrayobject.h>
+
+// system includes
 #include <typeindex>
 #include <type_traits>
+#include <climits>
 
 namespace LvArray
 {
@@ -49,21 +53,30 @@ namespace internal
  * @param tid the type_info object to use
  */
 int getFlags( const std::type_info& tid ){
-    if ( std::type_index( tid ) == std::type_index( typeid( char ) ) )
+    if ( std::type_index( tid ) == std::type_index( typeid( char ) ) ){
+        if ( CHAR_MIN < 0 )
+            return NPY_BYTE;
+        return NPY_UBYTE;
+    }
+    if ( std::type_index( tid ) == std::type_index( typeid( signed char ) ) )
         return NPY_BYTE;
+    else if ( std::type_index( tid ) == std::type_index( typeid( unsigned char ) ) )
+        return NPY_UBYTE;
     else if ( std::type_index( tid ) == std::type_index( typeid( short ) ) )
         return NPY_SHORT;
+    else if ( std::type_index( tid ) == std::type_index( typeid( unsigned short ) ) )
+        return NPY_USHORT;
     else if ( std::type_index( tid ) == std::type_index( typeid( int ) ) )
         return NPY_INT;
     else if ( std::type_index( tid ) == std::type_index( typeid( unsigned int ) ) )
         return NPY_UINT;
     else if ( std::type_index( tid ) == std::type_index( typeid( long ) ) )
         return NPY_LONG;
-    else if ( std::type_index( tid ) == std::type_index( typeid( long ) ) )
+    else if ( std::type_index( tid ) == std::type_index( typeid( unsigned long ) ) )
         return NPY_ULONG;
     else if ( std::type_index( tid ) == std::type_index( typeid( long long ) ) )
         return NPY_LONGLONG;
-    else if ( std::type_index( tid ) == std::type_index( typeid( long long ) ) )
+    else if ( std::type_index( tid ) == std::type_index( typeid( unsigned long long ) ) )
         return NPY_ULONGLONG;
     else if ( std::type_index( tid ) == std::type_index( typeid( float ) ) )
         return NPY_FLOAT;
@@ -79,6 +92,8 @@ int getFlags( const std::type_info& tid ){
 
 /**
  * @brief Create a numpy ndarray representing the given array. If T is const then the array should be immutable.
+ * @tparam T the type of each entry in the array
+ * @tparam INDEX_TYPE the integer type used to index the array, will be converted to npy_intp
  * @param data a pointer to the array.
  * @param ndim the number of dimensions in the array.
  * @param dims the number of elements in each dimension.

--- a/src/python/numpySortedArrayView.hpp
+++ b/src/python/numpySortedArrayView.hpp
@@ -1,0 +1,47 @@
+/*
+ *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory
+ *
+ * LLNL-CODE-746361
+ *
+ * All rights reserved. See COPYRIGHT for details.
+ *
+ * This file is part of the GEOSX Simulation Framework.
+ *
+ * GEOSX is a free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (as published by the
+ * Free Software Foundation) version 2.1 dated February 1999.
+ *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+
+/**
+ * @file numpySortedArrayView.hpp
+ */
+
+#pragma once
+#include "numpyConversion.hpp"
+#include "../SortedArrayView.hpp"
+
+namespace LvArray
+{
+
+namespace python
+{
+
+/**
+ * Return a Numpy view of a SortedArray
+ * @param arr the SortedArrayView to convert to numpy.
+ */
+template< typename T, typename INDEX_TYPE, template<typename> class BUFFER_TYPE >
+PyObject * create( SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE > const & arr ){
+    arr.move( MemorySpace::CPU );
+    INDEX_TYPE dims = arr.size();
+    INDEX_TYPE strides = 1;
+    return internal::create( arr.data(), 1, &dims, &strides);
+}
+
+} // namespace python
+
+} // namespace LvArray

--- a/src/python/numpySortedArrayView.hpp
+++ b/src/python/numpySortedArrayView.hpp
@@ -21,6 +21,8 @@
  */
 
 #pragma once
+
+// source includes
 #include "numpyConversion.hpp"
 #include "../SortedArrayView.hpp"
 
@@ -31,14 +33,20 @@ namespace python
 {
 
 /**
- * Return a Numpy view of a SortedArray
+ * @brief Return a Numpy view of a SortedArrayView. This numpy view may not be resized and
+ *		  the contents may not be modified. The numpy view will be invalidated if the array
+ *		  is reallocated.
+ * @tparam T type of data that is contained by the array.
+ * @tparam INDEX_TYPE the integer to use for indexing.
+ * @tparam BUFFER_TYPE A class that defines how to actually allocate memory for the array. Must take
+ *         one template argument that describes the type of the data being stored (T).
  * @param arr the SortedArrayView to convert to numpy.
  */
 template< typename T, typename INDEX_TYPE, template<typename> class BUFFER_TYPE >
 PyObject * create( SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE > const & arr ){
     arr.move( MemorySpace::CPU );
-    INDEX_TYPE dims = arr.size();
-    INDEX_TYPE strides = 1;
+    INDEX_TYPE const dims = arr.size();
+    INDEX_TYPE const strides = 1;
     return internal::create( arr.data(), 1, &dims, &strides);
 }
 

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -110,3 +110,8 @@ target_include_directories( testTensorOps PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../sr
 
 blt_add_test( NAME testTensorOps
               COMMAND testTensorOps )
+
+
+if( ENABLE_PYTHON )
+    add_subdirectory( python )
+endif()

--- a/unitTests/python/CMakeLists.txt
+++ b/unitTests/python/CMakeLists.txt
@@ -1,0 +1,25 @@
+set( pythonTests
+     testPythonArray.cpp
+     testPythonSortedArray.cpp
+    )
+
+foreach(test ${pythonTests})
+    get_filename_component( test_name ${test} NAME_WE )
+
+    blt_add_library( NAME ${test_name}
+                     SOURCES ${test} ${test_name}.c
+                     HEADERS ${test_name}.h
+                     DEPENDS_ON lvarray Python3::Python Python3::NumPy
+                     SHARED TRUE
+                     CLEAR_PREFIX TRUE
+                    )
+
+    target_include_directories( ${test_name} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../../src )
+
+    add_test( NAME ${test_name}
+              COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}Driver.py )
+
+    set_tests_properties( ${test_name}
+                          PROPERTIES ENVIRONMENT PYTHONPATH=${CMAKE_BINARY_DIR}/lib )
+
+endforeach()

--- a/unitTests/python/testPythonArray.c
+++ b/unitTests/python/testPythonArray.c
@@ -1,11 +1,11 @@
 #define PY_SSIZE_T_CLEAN
 #define NPY_NO_DEPRECATED_API NPY_1_15_API_VERSION
 #define PY_ARRAY_UNIQUE_SYMBOL LvArray_ARRAY_API
-#include <Python.h>
 
-#include <numpy/arrayobject.h>
 #include "testPythonArray.h"
 
+#include <Python.h>
+#include <numpy/arrayobject.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/unitTests/python/testPythonArray.c
+++ b/unitTests/python/testPythonArray.c
@@ -1,0 +1,185 @@
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_15_API_VERSION
+#define PY_ARRAY_UNIQUE_SYMBOL LvArray_ARRAY_API
+#include <Python.h>
+
+#include <numpy/arrayobject.h>
+#include "testPythonArray.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Clear and initialize the global 1D Array with values beginning at
+ * an integer offset.
+ * NOTE: this may invalidate previous views of the array!
+ */
+static PyObject *
+set_array1d( PyObject *self, PyObject *args )
+{
+    (void) self;
+    int offset;
+    if ( !PyArg_ParseTuple( args, "i", &offset ) )
+        return NULL;
+    return initArray1dInt( offset );
+}
+
+/**
+ * Fetch the global 1D array and return a numpy view of it.
+ */
+static PyObject *
+get_array1d( PyObject *self, PyObject *args )
+{
+    (void) self;
+    (void) args;
+    return getArray1dInt();
+}
+
+/**
+ * Multiply the global Array by a factor. Return None.
+ */
+static PyObject *
+multiply_array1d( PyObject *self, PyObject *args )
+{
+    (void) self;
+    int factor;
+    if ( !PyArg_ParseTuple( args, "i", &factor ) )
+        return NULL;
+    multiplyArray1d( factor );
+    Py_RETURN_NONE;
+}
+
+
+/**
+ * Clear and initialize the global SortedArray of floats with `range(start, stop)`
+ * NOTE: this may invalidate previous views of the array!
+ */
+static PyObject *
+set_array4d( PyObject *self, PyObject *args )
+{
+    (void) self;
+    int offset;
+    if ( !PyArg_ParseTuple( args, "i", &offset ) )
+        return NULL;
+    return initArray4dDouble( offset);
+}
+
+/**
+ * Fetch the global SortedArray of floats and return a numpy view of it.
+ */
+static PyObject *
+get_array4d( PyObject *self, PyObject *args )
+{
+    (void) self;
+    (void) args;
+    return getArray4dDouble();
+}
+
+/**
+ * Multiply the global Array by a factor. Return None.
+ */
+static PyObject *
+multiply_array4d( PyObject *self, PyObject *args )
+{
+    (void) self;
+    int factor;
+    if ( !PyArg_ParseTuple( args, "i", &factor ) )
+        return NULL;
+    multiplyArray4dDouble( factor );
+    Py_RETURN_NONE;
+}
+
+/**
+ * Clear and initialize the global SortedArray of floats with `range(start, stop)`
+ * NOTE: this may invalidate previous views of the array!
+ */
+static PyObject *
+set_array2d( PyObject *self, PyObject *args )
+{
+    (void) self;
+    int offset;
+    if ( !PyArg_ParseTuple( args, "i", &offset ) )
+        return NULL;
+    return initArray2dChar( offset);
+}
+
+/**
+ * Fetch the global SortedArray of floats and return a numpy view of it.
+ */
+static PyObject *
+get_array2d( PyObject *self, PyObject *args )
+{
+    (void) self;
+    (void) args;
+    return getArray2dChar();
+}
+
+/**
+ * Multiply the global Array by a factor. Return None.
+ */
+static PyObject *
+multiply_array2d( PyObject *self, PyObject *args )
+{
+    (void) self;
+    int factor;
+    if ( !PyArg_ParseTuple( args, "i", &factor ) )
+        return NULL;
+    multiplyArray2dChar( factor );
+    Py_RETURN_NONE;
+}
+
+/**
+ * Array of functions and docstrings to export to Python
+ */
+static PyMethodDef LvArrayFuncs[] = {
+    {"set_array1d",  set_array1d, METH_VARARGS,
+     "Return the numpy representation of a the global 1D Array after initializing it `range(start, stop)`."},
+    {"get_array1d",  get_array1d, METH_NOARGS,
+     "Get the numpy representation of the global 1D Array."},
+    {"multiply_array1d",  multiply_array1d, METH_VARARGS,
+     "Multiply the contents of the global 1D Array."},
+    {"set_array4d",  set_array4d, METH_VARARGS,
+     "Return the numpy representation of a the global 4D Array after initializing it `range(start, stop)`."},
+    {"get_array4d",  get_array4d, METH_NOARGS,
+     "Get the numpy representation of the global 4D Array."},
+    {"multiply_array4d",  multiply_array4d, METH_VARARGS,
+     "Multiply the contents of the global 4D Array."},
+    {"set_array2d",  set_array2d, METH_VARARGS,
+     "Return the numpy representation of a the global 2D Array after initializing it `range(start, stop)`."},
+    {"get_array2d",  get_array2d, METH_NOARGS,
+     "Get the numpy representation of the global 2D Array."},
+    {"multiply_array2d",  multiply_array2d, METH_VARARGS,
+     "Multiply the contents of the global 2D Array."},
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+
+/**
+ * Initialize the module object for Python with the exported functions
+ */
+static struct PyModuleDef _testLvArrayPythonInterfacemodule = {
+    PyModuleDef_HEAD_INIT,
+    "testPythonArray",   /* name of module */
+    "Module for testing numpy views of LvArray::Array objects", /* module documentation, may be NULL */
+    -1,       /* size of per-interpreter state of the module,
+                 or -1 if the module keeps state in global variables. */
+    LvArrayFuncs,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+
+
+PyMODINIT_FUNC
+PyInit_testPythonArray(void)
+{
+    import_array();
+    return PyModule_Create(&_testLvArrayPythonInterfacemodule);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/unitTests/python/testPythonArray.cpp
+++ b/unitTests/python/testPythonArray.cpp
@@ -1,0 +1,112 @@
+#include "Array.hpp"
+#include "MallocBuffer.hpp"
+#include "python/numpyArrayView.hpp"
+#include "testPythonArray.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// global Array of ints
+static LvArray::Array< long long, 1, RAJA::PERM_I, std::ptrdiff_t, LvArray::MallocBuffer > array1dInt( 30 );
+// global 4D Array of doubles
+static LvArray::Array< double, 4, RAJA::PERM_LKIJ, std::ptrdiff_t, LvArray::MallocBuffer > array4dDouble( 5, 6, 7, 8 );
+// global 2D Array of chars
+static LvArray::Array< char, 2, RAJA::PERM_JI, std::ptrdiff_t, LvArray::MallocBuffer > array2dChar( 3, 4 );
+
+/**
+ * Initialize and return a Numpy view of the global 1D-Array of ints.
+ */
+PyObject * initArray1dInt( int offset){
+    forValuesInSlice( array1dInt.toSlice(), [&offset]( long long & value )
+    {
+        value = offset++;
+    } );
+    return getArray1dInt();
+}
+
+/**
+ * Fetch a Numpy view of the global 1D-Array of ints.
+ * Note this view may be invalidated by subsequent calls to `initArray1dInt`
+ */
+PyObject * getArray1dInt( void ){
+    return LvArray::python::create( array1dInt.toView() );
+}
+
+/**
+ * Multiply the global 1D Array of ints
+ * @param factor the multiplication factor
+ */
+void multiplyArray1d( int factor ){
+    for (long long& i : array1dInt)
+    {
+        i = factor * i;
+    }
+}
+
+/**
+ * Initialize and return a Numpy view of the global 4D-Array of doubles.
+ */
+PyObject * initArray4dDouble( int offset ){
+    forValuesInSlice( array4dDouble.toSlice(), [&offset]( double & value )
+    {
+        value = offset++;
+    } );
+    return getArray4dDouble();
+}
+
+/**
+ * Fetch a Numpy view of the global 4D-Array of doubles.
+ * Note this view may be invalidated by subsequent calls to `initArray4dLongLong`
+ */
+PyObject * getArray4dDouble( void ){
+    return LvArray::python::create( array4dDouble.toView() );
+}
+
+/**
+ * Multiply the global 4D Array of doubles
+ * @param factor the multiplication factor
+ */
+void multiplyArray4dDouble( int factor ){
+    for (double& i : array4dDouble)
+    {
+        i = factor * i;
+    }
+}
+
+/**
+ * Initialize and return a Numpy view of the global 2D-Array of chars.
+ */
+PyObject * initArray2dChar( int offset ){
+    forValuesInSlice( array2dChar.toSlice(), [&offset]( char & value )
+    {
+        value = offset++;
+    } );
+    return getArray2dChar();
+}
+
+/**
+ * Fetch a Numpy view of the global 2D-Array of chars.
+ * Note this view may be invalidated by subsequent calls to `initArray4dLongLong`
+ */
+PyObject * getArray2dChar( void ){
+    return LvArray::python::create( array2dChar.toView() );
+}
+
+/**
+ * Multiply the global 2D-Array of chars
+ * @param factor the multiplication factor
+ */
+void multiplyArray2dChar( int factor ){
+    for (char & i : array2dChar)
+    {
+        i = factor * i;
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+

--- a/unitTests/python/testPythonArray.h
+++ b/unitTests/python/testPythonArray.h
@@ -1,0 +1,63 @@
+#pragma once
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialize and return a Numpy view of the global 1D-Array of ints.
+ */
+PyObject * initArray1dInt( int offset );
+
+/**
+ * Fetch a Numpy view of the global 1D-Array of ints.
+ * Note this view may be invalidated by subsequent calls to `initArray1dInt`
+ */
+PyObject * getArray1dInt( void );
+
+/**
+ * Multiply the global SortedArray of ints
+ * @param factor the multiplication factor
+ */
+void multiplyArray1d( int factor );
+
+/**
+ * Initialize and return a Numpy view of the global 4D-Array of doubles.
+ */
+PyObject * initArray4dDouble( int offset );
+
+/**
+ * Fetch a Numpy view of the global 4D-Array of doubles.
+ * Note this view may be invalidated by subsequent calls to `initArray4dLongLong`
+ */
+PyObject * getArray4dDouble( void );
+
+/**
+ * Multiply the global 4D Array of doubles
+ * @param factor the multiplication factor
+ */
+void multiplyArray4dDouble( int factor );
+
+/**
+ * Initialize and return a Numpy view of the global 2D-Array of chars.
+ */
+PyObject * initArray2dChar( int offset );
+
+/**
+ * Fetch a Numpy view of the global 2D-Array of chars.
+ * Note this view may be invalidated by subsequent calls to `initArray4dLongLong`
+ */
+PyObject * getArray2dChar( void );
+
+/**
+ * Multiply the global 2D-Array of chars
+ * @param factor the multiplication factor
+ */
+void multiplyArray2dChar( int factor );
+
+#ifdef __cplusplus
+}
+#endif

--- a/unitTests/python/testPythonArray.h
+++ b/unitTests/python/testPythonArray.h
@@ -2,7 +2,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/unitTests/python/testPythonArrayDriver.py
+++ b/unitTests/python/testPythonArrayDriver.py
@@ -1,0 +1,71 @@
+"""Tests for numpy views of LvArray::Array objects"""
+
+import unittest
+import itertools
+
+import numpy as np
+from numpy import testing
+
+import testPythonArray as lvarray
+
+
+class ArrayTests(unittest.TestCase):
+    """Tests for numpy views of LvArray::Array objects"""
+
+    LOWER_UPPER_PAIRS = ((0, 10), (1, 5), (-15, 15), (100, 200))
+    ARRAY_GET_SET_MULT_DIM = (
+        (lvarray.get_array1d, lvarray.set_array1d, lvarray.multiply_array1d, 1),
+        (lvarray.get_array4d, lvarray.set_array4d, lvarray.multiply_array4d, 4),
+        (lvarray.get_array2d, lvarray.set_array2d, lvarray.multiply_array2d, 2),
+    )
+
+    def test_resizing(self):
+        """Test that the Numpy views can't be resized"""
+        array1d = lvarray.set_array1d(0)
+        with self.assertRaisesRegex(ValueError, "own its data"):
+            array1d.resize((array1d.size * 2,))
+        array4d = lvarray.set_array4d(0)
+        with self.assertRaisesRegex(ValueError, "single-segment"):
+            array4d.resize((array4d.size * 2,))
+        array2d = lvarray.set_array2d(0)
+        with self.assertRaisesRegex(ValueError, "own its data"):
+            array2d.resize((array2d.size * 2,))
+
+    def test_init(self):
+        """Test initializing the arrays"""
+        for getter, setter, _, dims in self.ARRAY_GET_SET_MULT_DIM:
+            for offset_low, offset_high in self.LOWER_UPPER_PAIRS:
+                array_low = np.array(setter(offset_low))
+                array_high = np.array(setter(offset_high))
+                self.assertEqual(len(array_low.shape), dims)
+                self.assertEqual(array_low.shape, array_high.shape)
+                testing.assert_array_equal(
+                    array_low + (offset_high - offset_low), array_high
+                )
+
+    def test_multiply(self):
+        """Test that multiplying the values of the lvarray change the numpy representation"""
+        for getter, setter, multiplier, _ in self.ARRAY_GET_SET_MULT_DIM:
+            for offset in range(7):
+                for factor in range(1, 5):
+                    array_from_c = setter(offset)
+                    array_copy = np.array(array_from_c)
+                    testing.assert_array_equal(array_from_c, array_copy)
+                    multiplier(factor)
+                    testing.assert_array_equal(getter(), factor * array_copy)
+
+    def test_modification(self):
+        """Test that modifying a numpy view of an array modifies the underlying LvArray"""
+        for getter, setter, _, _ in self.ARRAY_GET_SET_MULT_DIM:
+            for offset in range(7):
+                for factor in range(2, 6):
+                    arr = setter(offset)
+                    unmodified_copy = np.array(arr)
+                    # modify the array
+                    arr *= factor
+                    testing.assert_array_equal(arr, unmodified_copy * factor)
+                    testing.assert_array_equal(getter(), arr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unitTests/python/testPythonSortedArray.c
+++ b/unitTests/python/testPythonSortedArray.c
@@ -1,0 +1,113 @@
+/*
+ *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ *
+ * Produced at the Lawrence Livermore National Laboratory
+ *
+ * LLNL-CODE-746361
+ *
+ * All rights reserved. See COPYRIGHT for details.
+ *
+ * This file is part of the GEOSX Simulation Framework.
+ *
+ * GEOSX is a free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License (as published by the
+ * Free Software Foundation) version 2.1 dated February 1999.
+ *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_15_API_VERSION
+#define PY_ARRAY_UNIQUE_SYMBOL LvArray_ARRAY_API
+#include <Python.h>
+
+#include <numpy/arrayobject.h>
+#include "testPythonSortedArray.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Clear and initialize the global SortedArray with `range(start, stop)`
+ * NOTE: this may invalidate previous views of the array!
+ */
+static PyObject *
+set_sorted_array_int( PyObject *self, PyObject *args )
+{
+    (void) self;
+    int start;
+    int stop;
+    if ( !PyArg_ParseTuple( args, "ii", &start, &stop ) )
+        return NULL;
+    if ( stop <= start ){
+        Py_RETURN_NONE;
+    }
+    return initSortedArrayInt( start, stop );
+}
+
+/**
+ * Fetch the global SortedArray and return a numpy view of it.
+ */
+static PyObject *
+get_sorted_array_int( PyObject *self, PyObject *args )
+{
+    (void) self;
+    (void) args;
+    return getSortedArrayInt();
+}
+
+/**
+ * Multiply the global SortedArray by a factor. Return None.
+ */
+static PyObject *
+multiply_sorted_array_int( PyObject *self, PyObject *args )
+{
+    (void) self;
+    int factor;
+    if ( !PyArg_ParseTuple( args, "i", &factor ) )
+        return NULL;
+    multiplySortedArrayInt( factor );
+    Py_RETURN_NONE;
+}
+
+/**
+ * Array of functions and docstrings to export to Python
+ */
+static PyMethodDef SortedArrayFuncs[] = {
+    {"set_sorted_array_int",  set_sorted_array_int, METH_VARARGS,
+     "Return the numpy representation of a SortedArray initialized like `range(start, stop)`."},
+    {"get_sorted_array_int",  get_sorted_array_int, METH_NOARGS,
+     "Get the numpy representation of a SortedArray."},
+    {"multiply_sorted_array_int",  multiply_sorted_array_int, METH_VARARGS,
+     "Multiply the contents of a SortedArray."},
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+/**
+ * Initialize the module object for Python with the exported functions
+ */
+static struct PyModuleDef testPythonSortedArraymodule = {
+    PyModuleDef_HEAD_INIT,
+    "testPythonArray",   /* name of module */
+    /* module documentation, may be NULL */
+    "Module for testing numpy views of LvArray::SortedArray objects",
+    -1,       /* size of per-interpreter state of the module,
+                 or -1 if the module keeps state in global variables. */
+    SortedArrayFuncs,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+
+PyMODINIT_FUNC
+PyInit_testPythonSortedArray(void)
+{
+    import_array();
+    return PyModule_Create(&testPythonSortedArraymodule);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/unitTests/python/testPythonSortedArray.c
+++ b/unitTests/python/testPythonSortedArray.c
@@ -19,10 +19,11 @@
 #define PY_SSIZE_T_CLEAN
 #define NPY_NO_DEPRECATED_API NPY_1_15_API_VERSION
 #define PY_ARRAY_UNIQUE_SYMBOL LvArray_ARRAY_API
-#include <Python.h>
 
-#include <numpy/arrayobject.h>
 #include "testPythonSortedArray.h"
+
+#include <Python.h>
+#include <numpy/arrayobject.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/unitTests/python/testPythonSortedArray.cpp
+++ b/unitTests/python/testPythonSortedArray.cpp
@@ -1,0 +1,47 @@
+#include "SortedArray.hpp"
+#include "MallocBuffer.hpp"
+#include "python/numpySortedArrayView.hpp"
+#include "testPythonSortedArray.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// global SortedArray of ints
+LvArray::SortedArray< int, std::ptrdiff_t, LvArray::MallocBuffer > sortedArrayInt;
+
+/**
+ * Initialize and return a Numpy view of the global SortedArray of ints.
+ */
+PyObject * initSortedArrayInt( int start, int stop ){
+    sortedArrayInt.clear();
+    for ( int i = start; i < stop; ++i )
+    {
+        sortedArrayInt.insert( i );
+    }
+    return getSortedArrayInt();
+}
+
+/**
+ * Fetch a Numpy view of the global SortedArray of ints.
+ * Note this view may be invalidated by subsequent calls to `initSortedArrayInt`
+ */
+PyObject * getSortedArrayInt( void ){
+    return LvArray::python::create( sortedArrayInt.toView() );
+}
+
+/**
+ * Multiply the global SortedArray of ints by a factor
+ */
+void multiplySortedArrayInt( int factor ){
+    LvArray::SortedArray< int, std::ptrdiff_t, LvArray::MallocBuffer > newSortedArray;
+    for (int i : sortedArrayInt)
+    {
+        newSortedArray.insert( factor * i );
+    }
+    sortedArrayInt = newSortedArray;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/unitTests/python/testPythonSortedArray.h
+++ b/unitTests/python/testPythonSortedArray.h
@@ -1,0 +1,29 @@
+#pragma once
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialize and return a Numpy view of the global SortedArray of ints.
+ */
+PyObject * initSortedArrayInt( int start, int stop );
+
+/**
+ * Fetch a Numpy view of the global SortedArray of ints.
+ * Note this view may be invalidated by subsequent calls to `initSortedArrayInt`
+ */
+PyObject * getSortedArrayInt( void );
+
+/**
+ * Multiply the global SortedArray of ints
+ * @param factor the multiplication factor
+ */
+void multiplySortedArrayInt( int factor );
+
+#ifdef __cplusplus
+}
+#endif

--- a/unitTests/python/testPythonSortedArray.h
+++ b/unitTests/python/testPythonSortedArray.h
@@ -1,7 +1,7 @@
 #pragma once
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
 
+#include <Python.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/unitTests/python/testPythonSortedArrayDriver.py
+++ b/unitTests/python/testPythonSortedArrayDriver.py
@@ -1,0 +1,63 @@
+"""Tests for the `lvarray` extension module"""
+
+import unittest
+import itertools
+
+import numpy as np
+from numpy import testing
+
+import testPythonSortedArray as lvarray
+
+
+class ArrayTests(unittest.TestCase):
+    """Tests for the `lvarray` extension module"""
+
+    LOWER_UPPER_PAIRS = ((0, 10), (1, 5), (-15, 15), (100, 200))
+    GETTER_SETTER_PAIRS = (
+        (lvarray.get_sorted_array_int, lvarray.set_sorted_array_int),
+    )
+
+    def test_init(self):
+        """Test that the array is properly initialized"""
+        for getter, setter in self.GETTER_SETTER_PAIRS:
+            for lowerbound, upperbound in self.LOWER_UPPER_PAIRS:
+                array_from_c = setter(lowerbound, upperbound)
+                array_from_python = np.array(
+                    range(lowerbound, upperbound), dtype=array_from_c.dtype
+                )
+                testing.assert_array_equal(array_from_c, array_from_python)
+                testing.assert_array_equal(array_from_c, getter())
+
+    def test_modification(self):
+        """Test that SortedArrays can't be modified"""
+        for getter, setter in self.GETTER_SETTER_PAIRS:
+            for lowerbound, upperbound in self.LOWER_UPPER_PAIRS:
+                array_from_c = setter(lowerbound, upperbound)
+                testing.assert_array_equal(array_from_c, np.sort(array_from_c))
+                with self.assertRaisesRegex(ValueError, "read-only"):
+                    array_from_c *= 2
+                with self.assertRaisesRegex(ValueError, "read-only"):
+                    array_from_c[0] = 1
+
+    def test_resizing(self):
+        """Test that the SortedArrays can't be resized"""
+        for _, setter in self.GETTER_SETTER_PAIRS:
+            array_from_c = setter(0, 10)
+            with self.assertRaisesRegex(ValueError, "own its data"):
+                array_from_c.resize((100,))
+
+    def test_multiply(self):
+        """Test that the array is properly initialized"""
+        for lowerbound, upperbound in self.LOWER_UPPER_PAIRS:
+            for factor in range(1, 5):
+                array_from_c = lvarray.set_sorted_array_int(lowerbound, upperbound)
+                array_copy = np.array(array_from_c)
+                testing.assert_array_equal(array_from_c, array_copy)
+                lvarray.multiply_sorted_array_int(factor)
+                testing.assert_array_equal(
+                    lvarray.get_sorted_array_int(), factor * array_copy
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds functions for returning Numpy views of ArrayView and SortedArrayView objects. With a Python extension module, these views can then be manipulated in Python. All that's needed is to pass the objects to one of the functions added in `src/python`. These will return a `PyObject_t *` which should be passed to the Python interpreter. There are two python extension modules, used for testing, in `unitTests/python`. 