### PR TITLE
re-enable range checking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ if( NOT is_submodule )
     include( cmake/blt/SetupBLT.cmake )
     include( cmake/CMakeBasics.cmake )
     include( cmake/SetupTPL.cmake )
+else()
+    include( cmake/CMakeBasics.cmake )
 endif()
 
 include(cmake/Macros.cmake)

--- a/cmake/CMakeBasics.cmake
+++ b/cmake/CMakeBasics.cmake
@@ -1,10 +1,12 @@
 set(CMAKE_ENABLE_EXPORTS ON)
 
-message( "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}" )
 if( CMAKE_BUILD_TYPE MATCHES "Debug" )
-  set(ENABLE_ARRAY_BOUNDS_CHECK "ON" CACHE BOOL "")
+  message( "Bounds Checking Enabled" )
+  option( LVARRAY_BOUNDS_CHECK "" ON )
+else()
+  option( LVARRAY_BOUNDS_CHECK "" OFF )
 endif()
-option( ENABLE_ARRAY_BOUNDS_CHECK "" OFF )
+
 
 option( ENABLE_TOTALVIEW_OUTPUT "" OFF )
 
@@ -34,3 +36,4 @@ blt_append_custom_compiler_flag(FLAGS_VAR GEOSX_NINJA_FLAGS
 if( ${CMAKE_MAKE_PROGRAM} STREQUAL "ninja" OR ${CMAKE_MAKE_PROGRAM} MATCHES ".*/ninja$" )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GEOSX_NINJA_FLAGS}")
 endif()
+

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -1,6 +1,5 @@
 #
-set( PREPROCESSOR_DEFINES ARRAY_BOUNDS_CHECK
-                          CHAI
+set( PREPROCESSOR_DEFINES CHAI
                           CUDA
                           MPI
                           TOTALVIEW_OUTPUT

--- a/docs/doxygen/LvArrayConfig.hpp
+++ b/docs/doxygen/LvArrayConfig.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-/* #undef LVARRAY_BOUNDS_CHECK */
+#define LVARRAY_BOUNDS_CHECK
 
 #define LVARRAY_USE_CHAI
 


### PR DESCRIPTION
The cmake variable had the wrong name when compared with the assumed preprocessor variable. I just did a direct define of the cmake variable rather than running through the config.cmake routines since the pattern is different. To use the generic pattern we would have to rename the variable to `LVARRAY_USE_ARRAY_BOUNDS_CHECK`...or something that starts with `LVARRAY_USE`. 