### PR TITLE
Feature/rrsettgast/update tensor ops

### DIFF
--- a/docs/sphinx/tensorOps.rst
+++ b/docs/sphinx/tensorOps.rst
@@ -103,12 +103,12 @@ Variables
 --------------------------------------------------------------------------------------------------
 Operation                                              Function 
 ====================================================== ===========================================
-:math:`\mathbf{A} \leftarrow x y^T`                    ``tensorOps::AiBj< m, n >( A, x, y )``
-:math:`\mathbf{A} \leftarrow \mathbf{A} + x y^T`       ``tensorOps::plusAiBj< m, n >( A, x, y )``
-:math:`x \leftarrow \mathbf{A} y`                      ``tensorOps::AijBj< m, n >( x, A, y )``
-:math:`x \leftarrow x + \mathbf{A} y`                  ``tensorOps::plusAijBj< m, n >( x, A, y )``
-:math:`y \leftarrow \mathbf{A}^T x`                    ``tensorOps::AjiBj< n, m >( y, A, x )``
-:math:`y \leftarrow y + \mathbf{A}^T x`                ``tensorOps::plusAjiBj< n, m >( y, A, x )``
+:math:`\mathbf{A} \leftarrow x y^T`                    ``tensorOps::Rij_eq_AiBj< m, n >( A, x, y )``
+:math:`\mathbf{A} \leftarrow \mathbf{A} + x y^T`       ``tensorOps::Rij_add_AiBj< m, n >( A, x, y )``
+:math:`x \leftarrow \mathbf{A} y`                      ``tensorOps::Ri_eq_AijBj< m, n >( x, A, y )``
+:math:`x \leftarrow x + \mathbf{A} y`                  ``tensorOps::Ri_add_AijBj< m, n >( x, A, y )``
+:math:`y \leftarrow \mathbf{A}^T x`                    ``tensorOps::Ri_eq_AjiBj< n, m >( y, A, x )``
+:math:`y \leftarrow y + \mathbf{A}^T x`                ``tensorOps::Ri_add_AjiBj< n, m >( y, A, x )``
 ====================================================== ===========================================
 
 Matrix operations
@@ -130,13 +130,13 @@ Variables
 Operation                                              Function 
 =================================================================== ===============================================
 :math:`\mathbf{A} \leftarrow \mathbf{D}^T`                          ``tensorOps::transpose< m, n >( A, D )``
-:math:`\mathbf{A} \leftarrow \mathbf{B} \mathbf{C}`                 ``tensorOps::AikBkj< m, n, p >( A, B, C )``
-:math:`\mathbf{A} \leftarrow \mathbf{A} + \mathbf{B} \mathbf{C}`    ``tensorOps::plusAikBkj< m, n, p >( A, B, C )``
-:math:`\mathbf{B} \leftarrow \mathbf{A} \mathbf{C}^T`               ``tensorOps::AikBjk< m, p, n >( B, A, C )``
-:math:`\mathbf{B} \leftarrow \mathbf{B} + \mathbf{A} \mathbf{C}^T`  ``tensorOps::plusAikBjk< m, p, n >( B, A, C )``
-:math:`\mathbf{E} \leftarrow \mathbf{E} + \mathbf{A} \mathbf{A}^T`  ``tensorOps::plusAikAjk< m, n >( E, A )``
-:math:`\mathbf{C} \leftarrow \mathbf{B}^T \mathbf{A}`               ``tensorOps::AkiBkj< p, n, m >( C, B, A )``
-:math:`\mathbf{C} \leftarrow \mathbf{C} + \mathbf{B}^T \mathbf{A}`  ``tensorOps::plusAkiBkj< p, n, m >( C, B, A )``
+:math:`\mathbf{A} \leftarrow \mathbf{B} \mathbf{C}`                 ``tensorOps::Rij_eq_AikBkj< m, n, p >( A, B, C )``
+:math:`\mathbf{A} \leftarrow \mathbf{A} + \mathbf{B} \mathbf{C}`    ``tensorOps::Rij_add_AikBkj< m, n, p >( A, B, C )``
+:math:`\mathbf{B} \leftarrow \mathbf{A} \mathbf{C}^T`               ``tensorOps::Rij_eq_AikBjk< m, p, n >( B, A, C )``
+:math:`\mathbf{B} \leftarrow \mathbf{B} + \mathbf{A} \mathbf{C}^T`  ``tensorOps::Rij_add_AikBjk< m, p, n >( B, A, C )``
+:math:`\mathbf{E} \leftarrow \mathbf{E} + \mathbf{A} \mathbf{A}^T`  ``tensorOps::Rij_add_AikAjk< m, n >( E, A )``
+:math:`\mathbf{C} \leftarrow \mathbf{B}^T \mathbf{A}`               ``tensorOps::Rij_eq_AkiBkj< p, n, m >( C, B, A )``
+:math:`\mathbf{C} \leftarrow \mathbf{C} + \mathbf{B}^T \mathbf{A}`  ``tensorOps::Rij_add_AkiBkj< p, n, m >( C, B, A )``
 =================================================================== ===============================================
 
 Square matrix operations
@@ -188,10 +188,10 @@ Operation                                                                       
 ================================================================================ ==============================================
 :math:`\mathbf{S} \leftarrow \mathbf{S} + \alpha \mathbf{I}`                     ``tensorOps::symAddIdentity< m >( S, alpha )``
 :math:`tr(\mathbf{S})`                                                           ``tensorOps::symTrace< m >( S )``
-:math:`x \leftarrow \mathbf{S} y`                                                ``tensorOps::symAijBj< m >( x, S ,y )``
-:math:`x \leftarrow x + \mathbf{S} y`                                            ``tensorOps::plusSymAijBj< m >( x, S ,y )``
-:math:`\mathbf{A} \leftarrow \mathbf{S} \mathbf{B}^T`                            ``tensorOps::symAikBjk< m >( A, S, B )``
-:math:`\mathbf{S} \leftarrow \mathbf{A} \mathbf{Q} \mathbf{A}^T`                 ``tensorOps::AikSymBklAjl< m >( S, A, Q )``
+:math:`x \leftarrow \mathbf{S} y`                                                ``tensorOps::Ri_eq_symAijBj< m >( x, S ,y )``
+:math:`x \leftarrow x + \mathbf{S} y`                                            ``tensorOps::Ri_add_symAijBj< m >( x, S ,y )``
+:math:`\mathbf{A} \leftarrow \mathbf{S} \mathbf{B}^T`                            ``tensorOps::Rij_eq_symAikBjk< m >( A, S, B )``
+:math:`\mathbf{S} \leftarrow \mathbf{A} \mathbf{Q} \mathbf{A}^T`                 ``tensorOps::Rij_eq_AikSymBklAjl< m >( S, A, Q )``
 :math:`|\mathbf{S}|`                                                             ``tensorOps::symDeterminant< m >( S )``
 :math:`\mathbf{S} \leftarrow \mathbf{Q}^-1`                                      ``tensorOps::symInvert< m >( S, Q )``
 :math:`\mathbf{S} \leftarrow \mathbf{S}^-1`                                      ``tensorOps::symInvert< m >( S )``

--- a/examples/exampleTensorOps.cpp
+++ b/examples/exampleTensorOps.cpp
@@ -98,7 +98,7 @@ CUDA_TEST( tensorOps, device )
     float x[ 3 ] = { 1.3f, 2.2f, 5.3f };
 
     // You can mix value types.
-    LvArray::tensorOps::symAijBj< 3 >( result, symmetricMatricesView[ i ], x );
+    LvArray::tensorOps::Ri_eq_symAijBj< 3 >( result, symmetricMatricesView[ i ], x );
 
     LVARRAY_ERROR_IF_NE( result[ 0 ], x[ 0 ] * symmetricMatricesView( i, 0 ) +
                          x[ 1 ] * symmetricMatricesView( i, 5 ) +

--- a/host-configs/LLNL/lassen-clang@upstream.cmake
+++ b/host-configs/LLNL/lassen-clang@upstream.cmake
@@ -54,7 +54,7 @@ set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-g -lineinfo ${CMAKE_CUDA_FLAGS_RELEASE}" C
 set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
 
 # Uncomment this line to make nvcc output register usage for each kernel.
- set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --resource-usage" CACHE STRING "" FORCE)
+#set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --resource-usage" CACHE STRING "" FORCE)
 
 # GTEST options
 set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")

--- a/host-configs/LLNL/lassen-clang@upstream.cmake
+++ b/host-configs/LLNL/lassen-clang@upstream.cmake
@@ -54,7 +54,7 @@ set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "-g -lineinfo ${CMAKE_CUDA_FLAGS_RELEASE}" C
 set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
 
 # Uncomment this line to make nvcc output register usage for each kernel.
-# set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --resource-usage" CACHE STRING "" FORCE)
+ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --resource-usage" CACHE STRING "" FORCE)
 
 # GTEST options
 set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")

--- a/src/fixedSizeSquareMatrixOps.hpp
+++ b/src/fixedSizeSquareMatrixOps.hpp
@@ -97,11 +97,11 @@ auto invert( MATRIX && matrix )
  */
 template< std::ptrdiff_t M, typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
+void Ri_eq_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
                VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  internal::SquareMatrixOps< M >::symAijBj( std::forward< DST_VECTOR >( dstVector ),
+  internal::SquareMatrixOps< M >::Ri_eq_symAijBj( std::forward< DST_VECTOR >( dstVector ),
                                             symMatrixA,
                                             vectorB );
 }
@@ -119,11 +119,11 @@ void symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
  */
 template< std::ptrdiff_t M, typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void plusSymAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
+void Ri_add_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                    SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
                    VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  internal::SquareMatrixOps< M >::plusSymAijBj( std::forward< DST_VECTOR >( dstVector ),
+  internal::SquareMatrixOps< M >::Ri_add_symAijBj( std::forward< DST_VECTOR >( dstVector ),
                                                 symMatrixA,
                                                 vectorB );
 }
@@ -142,11 +142,11 @@ void plusSymAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
  */
 template< std::ptrdiff_t M, typename DST_MATRIX, typename SYM_MATRIX_A, typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void symAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+void Rij_eq_symAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                 SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
                 MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  internal::SquareMatrixOps< M >::symAikBjk( std::forward< DST_MATRIX >( dstMatrix ),
+  internal::SquareMatrixOps< M >::Rij_eq_symAikBjk( std::forward< DST_MATRIX >( dstMatrix ),
                                              symMatrixA,
                                              matrixB );
 }
@@ -167,11 +167,11 @@ void symAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
  */
 template< std::ptrdiff_t M, typename DST_SYM_MATRIX, typename MATRIX_A, typename SYM_MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void AikSymBklAjl( DST_SYM_MATRIX && LVARRAY_RESTRICT_REF dstSymMatrix,
+void Rij_eq_AikSymBklAjl( DST_SYM_MATRIX && LVARRAY_RESTRICT_REF dstSymMatrix,
                    MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                    SYM_MATRIX_B const & LVARRAY_RESTRICT_REF symMatrixB )
 {
-  internal::SquareMatrixOps< M >::AikSymBklAjl( std::forward< DST_SYM_MATRIX >( dstSymMatrix ),
+  internal::SquareMatrixOps< M >::Rij_eq_AikSymBklAjl( std::forward< DST_SYM_MATRIX >( dstSymMatrix ),
                                                 matrixA,
                                                 symMatrixB );
 }

--- a/src/fixedSizeSquareMatrixOps.hpp
+++ b/src/fixedSizeSquareMatrixOps.hpp
@@ -98,12 +98,12 @@ auto invert( MATRIX && matrix )
 template< std::ptrdiff_t M, typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Ri_eq_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
-               SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
-               VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                     SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
+                     VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
   internal::SquareMatrixOps< M >::Ri_eq_symAijBj( std::forward< DST_VECTOR >( dstVector ),
-                                            symMatrixA,
-                                            vectorB );
+                                                  symMatrixA,
+                                                  vectorB );
 }
 
 /**
@@ -120,12 +120,12 @@ void Ri_eq_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 template< std::ptrdiff_t M, typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Ri_add_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
-                   SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
-                   VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                      SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
+                      VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
   internal::SquareMatrixOps< M >::Ri_add_symAijBj( std::forward< DST_VECTOR >( dstVector ),
-                                                symMatrixA,
-                                                vectorB );
+                                                   symMatrixA,
+                                                   vectorB );
 }
 
 /**
@@ -143,12 +143,12 @@ void Ri_add_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 template< std::ptrdiff_t M, typename DST_MATRIX, typename SYM_MATRIX_A, typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_eq_symAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-                SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
-                MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
+                       SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
+                       MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
   internal::SquareMatrixOps< M >::Rij_eq_symAikBjk( std::forward< DST_MATRIX >( dstMatrix ),
-                                             symMatrixA,
-                                             matrixB );
+                                                    symMatrixA,
+                                                    matrixB );
 }
 
 /**
@@ -168,12 +168,12 @@ void Rij_eq_symAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 template< std::ptrdiff_t M, typename DST_SYM_MATRIX, typename MATRIX_A, typename SYM_MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_eq_AikSymBklAjl( DST_SYM_MATRIX && LVARRAY_RESTRICT_REF dstSymMatrix,
-                   MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-                   SYM_MATRIX_B const & LVARRAY_RESTRICT_REF symMatrixB )
+                          MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                          SYM_MATRIX_B const & LVARRAY_RESTRICT_REF symMatrixB )
 {
   internal::SquareMatrixOps< M >::Rij_eq_AikSymBklAjl( std::forward< DST_SYM_MATRIX >( dstSymMatrix ),
-                                                matrixA,
-                                                symMatrixB );
+                                                       matrixA,
+                                                       symMatrixB );
 }
 
 /**

--- a/src/fixedSizeSquareMatrixOpsImpl.hpp
+++ b/src/fixedSizeSquareMatrixOpsImpl.hpp
@@ -223,7 +223,7 @@ struct SquareMatrixOps< 2 >
    */
   template< typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  static void symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
+  static void Ri_eq_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                         SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
                         VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
   {
@@ -247,7 +247,7 @@ struct SquareMatrixOps< 2 >
    */
   template< typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  static void plusSymAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
+  static void Ri_add_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                             SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
                             VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
   {
@@ -272,7 +272,7 @@ struct SquareMatrixOps< 2 >
    */
   template< typename DST_MATRIX, typename SYM_MATRIX_A, typename MATRIX_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  static void symAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+  static void Rij_eq_symAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                          SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
                          MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
   {
@@ -302,7 +302,7 @@ struct SquareMatrixOps< 2 >
    */
   template< typename DST_SYM_MATRIX, typename MATRIX_A, typename SYM_MATRIX_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  static void AikSymBklAjl( DST_SYM_MATRIX && LVARRAY_RESTRICT_REF dstSymMatrix,
+  static void Rij_eq_AikSymBklAjl( DST_SYM_MATRIX && LVARRAY_RESTRICT_REF dstSymMatrix,
                             MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                             SYM_MATRIX_B const & LVARRAY_RESTRICT_REF symMatrixB )
   {
@@ -693,7 +693,7 @@ struct SquareMatrixOps< 3 >
    */
   template< typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  static void symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
+  static void Ri_eq_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                         SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
                         VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
   {
@@ -724,7 +724,7 @@ struct SquareMatrixOps< 3 >
    */
   template< typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  static void plusSymAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
+  static void Ri_add_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                             SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
                             VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
   {
@@ -759,7 +759,7 @@ struct SquareMatrixOps< 3 >
    */
   template< typename DST_MATRIX, typename SYM_MATRIX_A, typename MATRIX_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  static void symAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+  static void Rij_eq_symAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                          SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
                          MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
   {
@@ -813,7 +813,7 @@ struct SquareMatrixOps< 3 >
    */
   template< typename DST_SYM_MATRIX, typename MATRIX_A, typename SYM_MATRIX_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  static void AikSymBklAjl( DST_SYM_MATRIX && LVARRAY_RESTRICT_REF dstSymMatrix,
+  static void Rij_eq_AikSymBklAjl( DST_SYM_MATRIX && LVARRAY_RESTRICT_REF dstSymMatrix,
                             MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                             SYM_MATRIX_B const & LVARRAY_RESTRICT_REF symMatrixB )
   {

--- a/src/fixedSizeSquareMatrixOpsImpl.hpp
+++ b/src/fixedSizeSquareMatrixOpsImpl.hpp
@@ -224,8 +224,8 @@ struct SquareMatrixOps< 2 >
   template< typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
   static void Ri_eq_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
-                        SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
-                        VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                              SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
+                              VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
   {
     checkSizes< 2 >( dstVector );
     checkSizes< 3 >( symMatrixA );
@@ -248,8 +248,8 @@ struct SquareMatrixOps< 2 >
   template< typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
   static void Ri_add_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
-                            SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
-                            VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                               SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
+                               VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
   {
     checkSizes< 2 >( dstVector );
     checkSizes< 3 >( symMatrixA );
@@ -273,8 +273,8 @@ struct SquareMatrixOps< 2 >
   template< typename DST_MATRIX, typename SYM_MATRIX_A, typename MATRIX_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
   static void Rij_eq_symAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-                         SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
-                         MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
+                                SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
+                                MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
   {
     checkSizes< 2, 2 >( dstMatrix );
     checkSizes< 3 >( symMatrixA );
@@ -303,8 +303,8 @@ struct SquareMatrixOps< 2 >
   template< typename DST_SYM_MATRIX, typename MATRIX_A, typename SYM_MATRIX_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
   static void Rij_eq_AikSymBklAjl( DST_SYM_MATRIX && LVARRAY_RESTRICT_REF dstSymMatrix,
-                            MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-                            SYM_MATRIX_B const & LVARRAY_RESTRICT_REF symMatrixB )
+                                   MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                                   SYM_MATRIX_B const & LVARRAY_RESTRICT_REF symMatrixB )
   {
     checkSizes< 3 >( dstSymMatrix );
     checkSizes< 2, 2 >( matrixA );
@@ -694,8 +694,8 @@ struct SquareMatrixOps< 3 >
   template< typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
   static void Ri_eq_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
-                        SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
-                        VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                              SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
+                              VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
   {
     checkSizes< 3 >( dstVector );
     checkSizes< 6 >( symMatrixA );
@@ -725,8 +725,8 @@ struct SquareMatrixOps< 3 >
   template< typename DST_VECTOR, typename SYM_MATRIX_A, typename VECTOR_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
   static void Ri_add_symAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
-                            SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
-                            VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                               SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
+                               VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
   {
     checkSizes< 3 >( dstVector );
     checkSizes< 6 >( symMatrixA );
@@ -760,8 +760,8 @@ struct SquareMatrixOps< 3 >
   template< typename DST_MATRIX, typename SYM_MATRIX_A, typename MATRIX_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
   static void Rij_eq_symAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-                         SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
-                         MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
+                                SYM_MATRIX_A const & LVARRAY_RESTRICT_REF symMatrixA,
+                                MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
   {
     checkSizes< 3, 3 >( dstMatrix );
     checkSizes< 6 >( symMatrixA );
@@ -814,8 +814,8 @@ struct SquareMatrixOps< 3 >
   template< typename DST_SYM_MATRIX, typename MATRIX_A, typename SYM_MATRIX_B >
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
   static void Rij_eq_AikSymBklAjl( DST_SYM_MATRIX && LVARRAY_RESTRICT_REF dstSymMatrix,
-                            MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-                            SYM_MATRIX_B const & LVARRAY_RESTRICT_REF symMatrixB )
+                                   MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                                   SYM_MATRIX_B const & LVARRAY_RESTRICT_REF symMatrixB )
   {
     checkSizes< 6 >( dstSymMatrix );
     checkSizes< 3, 3 >( matrixA );

--- a/src/genericTensorOps.hpp
+++ b/src/genericTensorOps.hpp
@@ -270,7 +270,7 @@ template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto maxAbsoluteEntry( VECTOR && vector )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( vector );
 
   auto maxVal = math::abs( vector[ 0 ] );
@@ -294,7 +294,7 @@ template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void fill( VECTOR && vector, std::remove_reference_t< decltype( vector[ 0 ] ) > const value )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( vector );
 
   for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
@@ -316,8 +316,8 @@ template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void fill( MATRIX && matrix, std::remove_reference_t< decltype( matrix[ 0 ][ 0 ] ) > const value )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( matrix );
 
   for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
@@ -368,8 +368,8 @@ LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void copy( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
            SRC_MATRIX const & LVARRAY_RESTRICT_REF srcMatrix )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
   internal::checkSizes< ISIZE, JSIZE >( srcMatrix );
 
@@ -394,7 +394,7 @@ template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void scale( VECTOR && vector, std::remove_reference_t< decltype( vector[ 0 ] ) > const scale )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( vector );
 
   for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
@@ -416,8 +416,8 @@ template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void scale( MATRIX && matrix, std::remove_reference_t< decltype( matrix[ 0 ][ 0 ] ) > const scale )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( matrix );
 
   for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
@@ -445,7 +445,7 @@ void scaledCopy( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                  SRC_VECTOR const & LVARRAY_RESTRICT_REF srcVector,
                  std::remove_reference_t< decltype( srcVector[ 0 ] ) > const scale )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( dstVector );
   internal::checkSizes< ISIZE >( srcVector );
 
@@ -472,8 +472,8 @@ void scaledCopy( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                  SRC_MATRIX const & LVARRAY_RESTRICT_REF srcMatrix,
                  std::remove_reference_t< decltype( srcMatrix[ 0 ][ 0 ] ) > const scale )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
   internal::checkSizes< ISIZE, JSIZE >( srcMatrix );
 
@@ -500,7 +500,7 @@ LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void add( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
           SRC_VECTOR const & LVARRAY_RESTRICT_REF srcVector )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( dstVector );
   internal::checkSizes< ISIZE >( srcVector );
 
@@ -525,8 +525,8 @@ LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void add( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
           SRC_MATRIX const & LVARRAY_RESTRICT_REF srcMatrix )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
   internal::checkSizes< ISIZE, JSIZE >( srcMatrix );
 
@@ -553,7 +553,7 @@ LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void subtract( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                SRC_VECTOR const & LVARRAY_RESTRICT_REF srcVector )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( dstVector );
   internal::checkSizes< ISIZE >( srcVector );
 
@@ -579,7 +579,7 @@ void scaledAdd( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                 SRC_VECTOR const & LVARRAY_RESTRICT_REF srcVector,
                 std::remove_reference_t< decltype( srcVector[ 0 ] ) > const scale )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( dstVector );
   internal::checkSizes< ISIZE >( srcVector );
 
@@ -605,7 +605,7 @@ void hadamardProduct( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                       VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
                       VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( dstVector );
   internal::checkSizes< ISIZE >( vectorA );
   internal::checkSizes< ISIZE >( vectorB );
@@ -634,7 +634,7 @@ template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto l2NormSquared( VECTOR const & vector )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( vector );
 
   auto norm = vector[ 0 ] * vector[ 0 ];
@@ -655,7 +655,7 @@ template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto l2Norm( VECTOR const & vector )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( vector );
 
   return math::sqrt( l2NormSquared< ISIZE >( vector ) );
@@ -672,7 +672,7 @@ template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto normalize( VECTOR && vector )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( vector );
 
   auto const normInv = math::invSqrt( l2NormSquared< ISIZE >( vector ) );
@@ -694,7 +694,7 @@ LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto AiBi( VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
            VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< JSIZE >( vectorA );
   internal::checkSizes< JSIZE >( vectorB );
 
@@ -757,8 +757,8 @@ void Rij_eq_AiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                   VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
                   VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
   internal::checkSizes< ISIZE >( vectorA );
   internal::checkSizes< JSIZE >( vectorB );
@@ -790,8 +790,8 @@ void Rij_add_AiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                    VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
                    VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( JSIZE > 0, "N must be greater than zero." );
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< JSIZE, ISIZE >( dstMatrix );
   internal::checkSizes< JSIZE >( vectorA );
   internal::checkSizes< ISIZE >( vectorB );
@@ -823,8 +823,8 @@ void Ri_eq_AijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                   MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                   VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( dstVector );
   internal::checkSizes< ISIZE, JSIZE >( matrixA );
   internal::checkSizes< JSIZE >( vectorB );
@@ -857,8 +857,8 @@ void Ri_add_AijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                    MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                    VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( dstVector );
   internal::checkSizes< ISIZE, JSIZE >( matrixA );
   internal::checkSizes< JSIZE >( vectorB );
@@ -891,8 +891,8 @@ void Ri_eq_AjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                   MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                   VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( dstVector );
   internal::checkSizes< JSIZE, ISIZE >( matrixA );
   internal::checkSizes< JSIZE >( vectorB );
@@ -926,8 +926,8 @@ void Ri_add_AjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                    MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                    VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE >( dstVector );
   internal::checkSizes< JSIZE, ISIZE >( matrixA );
   internal::checkSizes< JSIZE >( vectorB );
@@ -963,8 +963,8 @@ LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void transpose( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                 SRC_MATRIX const & LVARRAY_RESTRICT_REF srcMatrix )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
   internal::checkSizes< JSIZE, ISIZE >( srcMatrix );
 
@@ -1002,9 +1002,9 @@ void Rij_eq_AikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                     MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                     MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( JSIZE > 0, "M must be greater than zero." );
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( KSIZE > 0, "P must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( KSIZE > 0, "KSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
   internal::checkSizes< ISIZE, KSIZE >( matrixA );
   internal::checkSizes< KSIZE, JSIZE >( matrixB );
@@ -1048,9 +1048,9 @@ void Rij_add_AikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                      MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                      MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "N must be greater than zero." );
-  static_assert( KSIZE > 0, "P must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
+  static_assert( KSIZE > 0, "KSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
   internal::checkSizes< ISIZE, KSIZE >( matrixA );
   internal::checkSizes< KSIZE, JSIZE >( matrixB );
@@ -1093,9 +1093,9 @@ void Rij_eq_AikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                     MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                     MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "M must be greater than zero." );
-  static_assert( KSIZE > 0, "P must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
+  static_assert( KSIZE > 0, "KSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
   internal::checkSizes< ISIZE, KSIZE >( matrixA );
   internal::checkSizes< JSIZE, KSIZE >( matrixB );
@@ -1139,9 +1139,9 @@ void Rij_add_AikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                      MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                      MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "N must be greater than zero." );
-  static_assert( KSIZE > 0, "P must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
+  static_assert( KSIZE > 0, "KSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
   internal::checkSizes< ISIZE, KSIZE >( matrixA );
   internal::checkSizes< JSIZE, KSIZE >( matrixB );
@@ -1177,8 +1177,8 @@ LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_add_AikAjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                      MATRIX_A const & LVARRAY_RESTRICT_REF matrixA )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, ISIZE >( dstMatrix );
   internal::checkSizes< ISIZE, JSIZE >( matrixA );
 
@@ -1219,9 +1219,9 @@ void Rij_eq_AkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                     MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                     MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "M must be greater than zero." );
-  static_assert( KSIZE > 0, "P must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
+  static_assert( KSIZE > 0, "KSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
   internal::checkSizes< KSIZE, ISIZE >( matrixA );
   internal::checkSizes< KSIZE, JSIZE >( matrixB );
@@ -1264,9 +1264,9 @@ void Rij_add_AkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                      MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                      MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
-  static_assert( JSIZE > 0, "M must be greater than zero." );
-  static_assert( KSIZE > 0, "P must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  static_assert( JSIZE > 0, "JSIZE must be greater than zero." );
+  static_assert( KSIZE > 0, "KSIZE must be greater than zero." );
   internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
   internal::checkSizes< KSIZE, ISIZE >( matrixA );
   internal::checkSizes< KSIZE, JSIZE >( matrixB );
@@ -1301,7 +1301,7 @@ template< std::ptrdiff_t ISIZE, typename MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void transpose( MATRIX && LVARRAY_RESTRICT_REF matrix )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE, ISIZE >( matrix );
 
   for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
@@ -1327,7 +1327,7 @@ template< std::ptrdiff_t ISIZE, typename MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void addIdentity( MATRIX && matrix, std::remove_reference_t< decltype( matrix[ 0 ][ 0 ] ) > const scale )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE, ISIZE >( matrix );
 
   for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
@@ -1346,7 +1346,7 @@ template< std::ptrdiff_t ISIZE, typename MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto trace( MATRIX const & matrix )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< ISIZE, ISIZE >( matrix );
 
   auto trace = matrix[ 0 ][ 0 ];
@@ -1378,7 +1378,7 @@ template< std::ptrdiff_t ISIZE, typename SYM_MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void symAddIdentity( SYM_MATRIX && symMatrix, std::remove_reference_t< decltype( symMatrix[ 0 ] ) > const scale )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< SYM_SIZE< ISIZE > >( symMatrix );
 
   for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
@@ -1397,7 +1397,7 @@ template< std::ptrdiff_t ISIZE, typename SYM_MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto symTrace( SYM_MATRIX const & symMatrix )
 {
-  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
   internal::checkSizes< SYM_SIZE< ISIZE > >( symMatrix );
 
   auto trace = symMatrix[ 0 ];

--- a/src/genericTensorOps.hpp
+++ b/src/genericTensorOps.hpp
@@ -35,7 +35,7 @@ class R1TensorT;
  *
  *   LVARRAY_TENSOROPS_ASSIGN_2( vectorA, 5, 3 );
  *
- *   Array< double, 2, ... > arrayOfMatrices( N, 2, 2 );
+ *   Array< double, 2, ... > arrayOfMatrices( JSIZE, 2, 2 );
  *   double matrix[ 2 ][ 2 ] = LVARRAY_TENSOROPS_INIT_LOCAL_2x2( arrayOfMatrices[ 0 ] );
  *
  *   LVARRAY_TENSOROPS_ASSIGN_2x2( arrayOfMatrices[ 0 ], a00, a01, a10, a11 );
@@ -210,17 +210,17 @@ void checkSizes( T const ( &src )[ INFERRED_M ][ INFERRED_N ] )
 
 /**
  * @brief Verify at compile time that @tparam ARRAY is 1D and at runtime verify the size when LVARRAY_BOUNDS_CHECK.
- * @tparam M The size expected size.
+ * @tparam ISIZE The size expected size.
  * @tparam ARRAY The type o @p array, should be an Array, ArrayView or ArraySlice.
  * @param array The array to check.
  */
-template< std::ptrdiff_t M, typename ARRAY >
+template< std::ptrdiff_t ISIZE, typename ARRAY >
 LVARRAY_HOST_DEVICE inline CONSTEXPR_WITHOUT_BOUNDS_CHECK
 void checkSizes( ARRAY const & array )
 {
   static_assert( ARRAY::NDIM == 1, "Must be a 1D array." );
   #ifdef LVARRAY_BOUNDS_CHECK
-  LVARRAY_ERROR_IF_NE( array.size( 0 ), M );
+  LVARRAY_ERROR_IF_NE( array.size( 0 ), ISIZE );
   #else
   LVARRAY_UNUSED_VARIABLE( array );
   #endif
@@ -228,19 +228,19 @@ void checkSizes( ARRAY const & array )
 
 /**
  * @brief Verify at compile time that @tparam ARRAY is 2D and at runtime verify the sizes when LVARRAY_BOUNDS_CHECK.
- * @tparam M The expected size of the first dimension.
- * @tparam N The expected size of the second dimension.
+ * @tparam ISIZE The expected size of the first dimension.
+ * @tparam JSIZE The expected size of the second dimension.
  * @tparam ARRAY The type o @p array, should be an Array, ArrayView or ArraySlice.
  * @param array The array to check.
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename ARRAY >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename ARRAY >
 LVARRAY_HOST_DEVICE inline CONSTEXPR_WITHOUT_BOUNDS_CHECK
 void checkSizes( ARRAY const & array )
 {
   static_assert( ARRAY::NDIM == 2, "Must be a 1D array." );
 #ifdef LVARRAY_BOUNDS_CHECK
-  LVARRAY_ERROR_IF_NE( array.size( 0 ), M );
-  LVARRAY_ERROR_IF_NE( array.size( 1 ), N );
+  LVARRAY_ERROR_IF_NE( array.size( 0 ), ISIZE );
+  LVARRAY_ERROR_IF_NE( array.size( 1 ), JSIZE );
 #else
   LVARRAY_UNUSED_VARIABLE( array );
 #endif
@@ -249,8 +249,8 @@ void checkSizes( ARRAY const & array )
 } // namespace internal
 
 /// The size of a symmetric MxM matrix in Voigt notation.
-template< std::ptrdiff_t M >
-constexpr std::ptrdiff_t SYM_SIZE = ( M * ( M + 1 ) ) / 2;
+template< std::ptrdiff_t ISIZE >
+constexpr std::ptrdiff_t SYM_SIZE = ( ISIZE * ( ISIZE + 1 ) ) / 2;
 
 /**
  * @name Generic operations
@@ -262,19 +262,19 @@ constexpr std::ptrdiff_t SYM_SIZE = ( M * ( M + 1 ) ) / 2;
 
 /**
  * @return Return the largest absolute entry of @p vector.
- * @tparam M The size of @p vector.
+ * @tparam ISIZE The size of @p vector.
  * @tparam VECTOR The type of @p vector.
  * @param vector The vector to get the maximum entry of, of length M.
  */
-template< std::ptrdiff_t M, typename VECTOR >
+template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto maxAbsoluteEntry( VECTOR && vector )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( vector );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( vector );
 
   auto maxVal = math::abs( vector[ 0 ] );
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     maxVal = math::max( maxVal, math::abs( vector[ i ] ) );
   }
@@ -284,20 +284,20 @@ auto maxAbsoluteEntry( VECTOR && vector )
 
 /**
  * @brief Set the entries of @p vector to @p value.
- * @tparam M The size of @p vector.
+ * @tparam ISIZE The size of @p vector.
  * @tparam VECTOR The type of @p vector.
  * @param vector The vector to set the entries of, of length M.
  * @param value The value to set the entries to.
  * @details Performs the operation @code vector[ i ] = value @endcode
  */
-template< std::ptrdiff_t M, typename VECTOR >
+template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void fill( VECTOR && vector, std::remove_reference_t< decltype( vector[ 0 ] ) > const value )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( vector );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( vector );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     vector[ i ] = value;
   }
@@ -305,24 +305,24 @@ void fill( VECTOR && vector, std::remove_reference_t< decltype( vector[ 0 ] ) > 
 
 /**
  * @brief Set the entries of @p matrix to @p value.
- * @tparam M The size of the first dimension of @p matrix.
- * @tparam N The size of the second dimension of @p matrix.
+ * @tparam ISIZE The size of the first dimension of @p matrix.
+ * @tparam JSIZE The size of the second dimension of @p matrix.
  * @tparam MATRIX The type of @p matrix.
- * @param matrix The matrix to set the entries of, of size M x N.
+ * @param matrix The matrix to set the entries of, of size ISIZE x N.
  * @param value The value to set the entries to.
  * @details Performs the operation @code matrix[ i ][ j ] = value @endcode
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename MATRIX >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void fill( MATRIX && matrix, std::remove_reference_t< decltype( matrix[ 0 ][ 0 ] ) > const value )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "N must be greater than zero." );
-  internal::checkSizes< M, N >( matrix );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( matrix );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
       matrix[ i ][ j ] = value;
     }
@@ -331,23 +331,23 @@ void fill( MATRIX && matrix, std::remove_reference_t< decltype( matrix[ 0 ][ 0 ]
 
 /**
  * @brief Copy @p srcVector into @p dstVector.
- * @tparam M The length of @p dstVector and @p srcVector.
+ * @tparam ISIZE The length of @p dstVector and @p srcVector.
  * @tparam DST_VECTOR The type of @p dstVector.
  * @tparam SRC_VECTOR The type of @p srcVector.
- * @param dstVector The destination vector, of length M.
- * @param srcVector The source vector, of length M.
+ * @param dstVector The destination vector, of length ISIZE.
+ * @param srcVector The source vector, of length ISIZE.
  * @details Performs the operation @code dstVector[ i ] = srcVector[ i ] @endcode
  */
-template< std::ptrdiff_t M, typename DST_VECTOR, typename SRC_VECTOR >
+template< std::ptrdiff_t ISIZE, typename DST_VECTOR, typename SRC_VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void copy( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
            SRC_VECTOR const & LVARRAY_RESTRICT_REF srcVector )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( dstVector );
-  internal::checkSizes< M >( srcVector );
+  static_assert( ISIZE > 0, "ISIZE must be greater than zero." );
+  internal::checkSizes< ISIZE >( dstVector );
+  internal::checkSizes< ISIZE >( srcVector );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     dstVector[ i ] = srcVector[ i ];
   }
@@ -355,27 +355,27 @@ void copy( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
 /**
  * @brief Copy @p srcMatrix into @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and @p srcMatrix.
- * @tparam N The size of the second dimension of @p dstMatrix and @p srcMatrix.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and @p srcMatrix.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and @p srcMatrix.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam SRC_MATRIX The type of @p srcMatrix.
- * @param dstMatrix The destination matrix, of size M x N.
- * @param srcMatrix The source matrix, of size M x N.
+ * @param dstMatrix The destination matrix, of size ISIZE x N.
+ * @param srcMatrix The source matrix, of size ISIZE x N.
  * @details Performs the operation @code dstMatrix[ i ][ j ] = srcMatrix[ i ][ j ] @endcode
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_MATRIX, typename SRC_MATRIX >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename DST_MATRIX, typename SRC_MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void copy( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
            SRC_MATRIX const & LVARRAY_RESTRICT_REF srcMatrix )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "N must be greater than zero." );
-  internal::checkSizes< M, N >( dstMatrix );
-  internal::checkSizes< M, N >( srcMatrix );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
+  internal::checkSizes< ISIZE, JSIZE >( srcMatrix );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
       dstMatrix[ i ][ j ] = srcMatrix[ i ][ j ];
     }
@@ -384,20 +384,20 @@ void copy( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Multiply the entries of @p vector by @p scale.
- * @tparam M The size of @p vector.
+ * @tparam ISIZE The size of @p vector.
  * @tparam VECTOR The type of @p vector.
  * @param vector The vector to scale, of length M.
  * @param scale The value to scale the entries of @p vector by.
  * @details Performs the operation @code vector[ i ] *= scale @endcode
  */
-template< std::ptrdiff_t M, typename VECTOR >
+template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void scale( VECTOR && vector, std::remove_reference_t< decltype( vector[ 0 ] ) > const scale )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( vector );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( vector );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     vector[ i ] *= scale;
   }
@@ -405,24 +405,24 @@ void scale( VECTOR && vector, std::remove_reference_t< decltype( vector[ 0 ] ) >
 
 /**
  * @brief Multiply the entries of @p matrix by @p scale.
- * @tparam M The size of the first dimension of @p matrix.
- * @tparam N The size of the second dimension of @p matrix.
+ * @tparam ISIZE The size of the first dimension of @p matrix.
+ * @tparam JSIZE The size of the second dimension of @p matrix.
  * @tparam MATRIX The type of @p matrix.
- * @param matrix The matrix to scale, of size M x N.
+ * @param matrix The matrix to scale, of size ISIZE x N.
  * @param scale The value scale the entries of @p vector by.
  * @details Performs the operations @code matrix[ i ][ j ] *= scale @endcode
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename MATRIX >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void scale( MATRIX && matrix, std::remove_reference_t< decltype( matrix[ 0 ][ 0 ] ) > const scale )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "N must be greater than zero." );
-  internal::checkSizes< M, N >( matrix );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( matrix );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
       matrix[ i ][ j ] *= scale;
     }
@@ -431,7 +431,7 @@ void scale( MATRIX && matrix, std::remove_reference_t< decltype( matrix[ 0 ][ 0 
 
 /**
  * @brief Copy @p srcVector scaled by @p scale into @p dstVector.
- * @tparam M The length of @p dstVector and @p srcVector.
+ * @tparam ISIZE The length of @p dstVector and @p srcVector.
  * @tparam DST_VECTOR The type of @p dstVector.
  * @tparam SRC_VECTOR The type of @p srcVector.
  * @param dstVector The destination vector, of length M.
@@ -439,17 +439,17 @@ void scale( MATRIX && matrix, std::remove_reference_t< decltype( matrix[ 0 ][ 0 
  * @param scale The value to scale @p srcVector by.
  * @details Performs the operations @code dstVector[ i ] = scale * srcVector[ i ] @endcode
  */
-template< std::ptrdiff_t M, typename DST_VECTOR, typename SRC_VECTOR >
+template< std::ptrdiff_t ISIZE, typename DST_VECTOR, typename SRC_VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void scaledCopy( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                  SRC_VECTOR const & LVARRAY_RESTRICT_REF srcVector,
                  std::remove_reference_t< decltype( srcVector[ 0 ] ) > const scale )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( dstVector );
-  internal::checkSizes< M >( srcVector );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( dstVector );
+  internal::checkSizes< ISIZE >( srcVector );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     dstVector[ i ] = scale * srcVector[ i ];
   }
@@ -457,29 +457,29 @@ void scaledCopy( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
 /**
  * @brief Copy @p srcMatrix scaled by @p scale into @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and @p srcMatrix.
- * @tparam N The size of the second dimension of @p dstMatrix and @p srcMatrix.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and @p srcMatrix.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and @p srcMatrix.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam SRC_MATRIX The type of @p srcMatrix.
- * @param dstMatrix The destination matrix, of size M x N.
- * @param srcMatrix The source matrix, of size M x N.
+ * @param dstMatrix The destination matrix, of size ISIZE x N.
+ * @param srcMatrix The source matrix, of size ISIZE x N.
  * @param scale The value to scale @p srcMatrix by.
  * @details Performs the operation @code dstMatrix[ i ][ j ] = scale * srcMatrix[ i ][ j ] @endcode
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_MATRIX, typename SRC_MATRIX >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename DST_MATRIX, typename SRC_MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void scaledCopy( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                  SRC_MATRIX const & LVARRAY_RESTRICT_REF srcMatrix,
                  std::remove_reference_t< decltype( srcMatrix[ 0 ][ 0 ] ) > const scale )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "N must be greater than zero." );
-  internal::checkSizes< M, N >( dstMatrix );
-  internal::checkSizes< M, N >( srcMatrix );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
+  internal::checkSizes< ISIZE, JSIZE >( srcMatrix );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
       dstMatrix[ i ][ j ] = scale * srcMatrix[ i ][ j ];
     }
@@ -488,23 +488,23 @@ void scaledCopy( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Add @p srcVector to @p dstVector.
- * @tparam M The length of @p dstVector and @p srcVector.
+ * @tparam ISIZE The length of @p dstVector and @p srcVector.
  * @tparam DST_VECTOR The type of @p dstVector.
  * @tparam SRC_VECTOR The type of @p srcVector.
  * @param dstVector The destination vector, of length M.
  * @param srcVector The source vector, of length M.
  * @details Performs the operation @code dstVector[ i ] += srcVector[ i ] @endcode
  */
-template< std::ptrdiff_t M, typename DST_VECTOR, typename SRC_VECTOR >
+template< std::ptrdiff_t ISIZE, typename DST_VECTOR, typename SRC_VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void add( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
           SRC_VECTOR const & LVARRAY_RESTRICT_REF srcVector )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( dstVector );
-  internal::checkSizes< M >( srcVector );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( dstVector );
+  internal::checkSizes< ISIZE >( srcVector );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     dstVector[ i ] += srcVector[ i ];
   }
@@ -512,27 +512,27 @@ void add( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
 /**
  * @brief Add @p srcMatrix to @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and @p srcMatrix.
- * @tparam N The size of the second dimension of @p dstMatrix and @p srcMatrix.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and @p srcMatrix.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and @p srcMatrix.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam SRC_MATRIX The type of @p srcMatrix.
- * @param dstMatrix The destination matrix, of size M x N.
- * @param srcMatrix The source matrix, of size M x N.
+ * @param dstMatrix The destination matrix, of size ISIZE x N.
+ * @param srcMatrix The source matrix, of size ISIZE x N.
  * @details Performs the operation @code dstMatrix[ i ][ j ] += srcMatrix[ i ][ j ] @endcode
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_MATRIX, typename SRC_MATRIX >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename DST_MATRIX, typename SRC_MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void add( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
           SRC_MATRIX const & LVARRAY_RESTRICT_REF srcMatrix )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "M must be greater than zero." );
-  internal::checkSizes< M, N >( dstMatrix );
-  internal::checkSizes< M, N >( srcMatrix );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
+  internal::checkSizes< ISIZE, JSIZE >( srcMatrix );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
       dstMatrix[ i ][ j ] += srcMatrix[ i ][ j ];
     }
@@ -541,23 +541,23 @@ void add( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Subtract @p srcVector from @p dstVector.
- * @tparam M The length of @p dstVector and @p srcVector.
+ * @tparam ISIZE The length of @p dstVector and @p srcVector.
  * @tparam DST_VECTOR The type of @p dstVector.
  * @tparam SRC_VECTOR The type of @p srcVector.
  * @param dstVector The destination vector, of length M.
  * @param srcVector The source vector, of length M.
  * @details Performs the operation @code dstVector[ i ] -= srcVector[ i ] @endcode
  */
-template< std::ptrdiff_t M, typename DST_VECTOR, typename SRC_VECTOR >
+template< std::ptrdiff_t ISIZE, typename DST_VECTOR, typename SRC_VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void subtract( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                SRC_VECTOR const & LVARRAY_RESTRICT_REF srcVector )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( dstVector );
-  internal::checkSizes< M >( srcVector );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( dstVector );
+  internal::checkSizes< ISIZE >( srcVector );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     dstVector[ i ] -= srcVector[ i ];
   }
@@ -565,7 +565,7 @@ void subtract( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
 /**
  * @brief Add @p srcVector scaled by @p scale to @p dstVector.
- * @tparam M The length of @p dstVector and @p srcVector.
+ * @tparam ISIZE The length of @p dstVector and @p srcVector.
  * @tparam DST_VECTOR The type of @p dstVector.
  * @tparam SRC_VECTOR The type of @p srcVector.
  * @param dstVector The destination vector, of length M.
@@ -573,17 +573,17 @@ void subtract( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
  * @param scale The value to scale the entries of @p srcVector by.
  * @details Performs the operation @code dstVector[ i ] += scale * srcVector[ i ] @endcode
  */
-template< std::ptrdiff_t M, typename DST_VECTOR, typename SRC_VECTOR >
+template< std::ptrdiff_t ISIZE, typename DST_VECTOR, typename SRC_VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void scaledAdd( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                 SRC_VECTOR const & LVARRAY_RESTRICT_REF srcVector,
                 std::remove_reference_t< decltype( srcVector[ 0 ] ) > const scale )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( dstVector );
-  internal::checkSizes< M >( srcVector );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( dstVector );
+  internal::checkSizes< ISIZE >( srcVector );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     dstVector[ i ] = dstVector[ i ] + scale * srcVector[ i ];
   }
@@ -591,7 +591,7 @@ void scaledAdd( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
 /**
  * @brief Multiply the elements of @p vectorA and @p vectorB putting the result into @p dstVector.
- * @tparam M The length of @p dstVector and @p srcVector.
+ * @tparam ISIZE The length of @p dstVector and @p srcVector.
  * @tparam DST_VECTOR The type of @p dstVector.
  * @tparam SRC_VECTOR The type of @p srcVector.
  * @param dstVector The destination vector, of length M.
@@ -599,18 +599,18 @@ void scaledAdd( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
  * @param vectorB The second source vector, of length M.
  * @details Performs the operation @code dstVector[ i ] = vectorA[ i ] * vectorB[ i ] @endcode
  */
-template< std::ptrdiff_t M, typename DST_VECTOR, typename VECTOR_A, typename VECTOR_B >
+template< std::ptrdiff_t ISIZE, typename DST_VECTOR, typename VECTOR_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void hadamardProduct( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                       VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
                       VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( dstVector );
-  internal::checkSizes< M >( vectorA );
-  internal::checkSizes< M >( vectorB );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( dstVector );
+  internal::checkSizes< ISIZE >( vectorA );
+  internal::checkSizes< ISIZE >( vectorB );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     dstVector[ i ] = vectorA[ i ] * vectorB[ i ];
   }
@@ -626,19 +626,19 @@ void hadamardProduct( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
 /**
  * @return The L2 norm squared of @p vector.
- * @tparam M The length of @p vector.
+ * @tparam ISIZE The length of @p vector.
  * @tparam VECTOR The type of @p vector.
  * @param vector The vector to get the L2 norm squared of, of length M.
  */
-template< std::ptrdiff_t M, typename VECTOR >
+template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto l2NormSquared( VECTOR const & vector )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( vector );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( vector );
 
   auto norm = vector[ 0 ] * vector[ 0 ];
-  for( std::ptrdiff_t i = 1; i < M; ++i )
+  for( std::ptrdiff_t i = 1; i < ISIZE; ++i )
   {
     norm = norm + vector[ i ] * vector[ i ];
   }
@@ -647,59 +647,59 @@ auto l2NormSquared( VECTOR const & vector )
 
 /**
  * @return The L2 norm of @p vector.
- * @tparam M The length of @p vector.
+ * @tparam ISIZE The length of @p vector.
  * @tparam VECTOR The type of @p vector.
  * @param vector The vector to get the L2 norm of, of length M.
  */
-template< std::ptrdiff_t M, typename VECTOR >
+template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto l2Norm( VECTOR const & vector )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( vector );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( vector );
 
-  return math::sqrt( l2NormSquared< M >( vector ) );
+  return math::sqrt( l2NormSquared< ISIZE >( vector ) );
 }
 
 /**
  * @brief Scale @p vector to a unit vector.
- * @tparam M The length of @p vector.
+ * @tparam ISIZE The length of @p vector.
  * @tparam VECTOR The type of @p vector.
  * @param vector The vector normalize, of length M.
  * @return The previous L2 norm of @p vector.
  */
-template< std::ptrdiff_t M, typename VECTOR >
+template< std::ptrdiff_t ISIZE, typename VECTOR >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto normalize( VECTOR && vector )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( vector );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( vector );
 
-  auto const normInv = math::invSqrt( l2NormSquared< M >( vector ) );
-  scale< M >( vector, normInv );
+  auto const normInv = math::invSqrt( l2NormSquared< ISIZE >( vector ) );
+  scale< ISIZE >( vector, normInv );
 
   return 1 / normInv;
 }
 
 /**
  * @return Return the inner product of @p vectorA and @p vectorB.
- * @tparam M The length of @p vectorA and @p vectorB.
+ * @tparam ISIZE The length of @p vectorA and @p vectorB.
  * @tparam VECTOR_A The type of @p vectorA.
  * @tparam VECTOR_B The type of @p vectorB.
  * @param vectorA The first vector in the inner product, of length M.
  * @param vectorB The second vector in the inner product, of length M.
  */
-template< std::ptrdiff_t N, typename VECTOR_A, typename VECTOR_B >
+template< std::ptrdiff_t JSIZE, typename VECTOR_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto AiBi( VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
            VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( N > 0, "N must be greater than zero." );
-  internal::checkSizes< N >( vectorA );
-  internal::checkSizes< N >( vectorB );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  internal::checkSizes< JSIZE >( vectorA );
+  internal::checkSizes< JSIZE >( vectorB );
 
   auto result = vectorA[ 0 ] * vectorB[ 0 ];
-  for( std::ptrdiff_t i = 1; i < N; ++i )
+  for( std::ptrdiff_t i = 1; i < JSIZE; ++i )
   {
     result = result + vectorA[ i ] * vectorB[ i ];
   }
@@ -741,31 +741,31 @@ void crossProduct( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
 /**
  * @brief Perform the outer product of @p vectorA and @p vectorB writing the result to @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and the length of @p vectorA.
- * @tparam N The size of the second dimension of @p dstMatrix and the length of @p vectorB.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and the length of @p vectorA.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and the length of @p vectorB.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam VECTOR_A The type of @p vectorA.
  * @tparam VECTOR_B The type of @p vectorB.
- * @param dstMatrix The matrix the result is written to, of size M x N.
+ * @param dstMatrix The matrix the result is written to, of size ISIZE x N.
  * @param vectorA The first vector in the outer product, of length M.
  * @param vectorB The second vector in the outer product, of length N.
  * @details Performs the operations @code dstMatrix[ i ][ j ] = vectorA[ i ] * vectorB[ j ] @endcode
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_MATRIX, typename VECTOR_A, typename VECTOR_B >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename DST_MATRIX, typename VECTOR_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_eq_AiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-           VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
-           VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                  VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
+                  VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "M must be greater than zero." );
-  internal::checkSizes< M, N >( dstMatrix );
-  internal::checkSizes< M >( vectorA );
-  internal::checkSizes< N >( vectorB );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
+  internal::checkSizes< ISIZE >( vectorA );
+  internal::checkSizes< JSIZE >( vectorB );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
       dstMatrix[ i ][ j ] = vectorA[ i ] * vectorB[ j ];
     }
@@ -774,31 +774,31 @@ void Rij_eq_AiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Perform the outer product of @p vectorA and @p vectorB adding the result to @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and the length of @p vectorA.
- * @tparam N The size of the second dimension of @p dstMatrix and the length of @p vectorB.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and the length of @p vectorA.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and the length of @p vectorB.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam VECTOR_A The type of @p vectorA.
  * @tparam VECTOR_B The type of @p vectorB.
- * @param dstMatrix The matrix the result is added to, of size M x N.
+ * @param dstMatrix The matrix the result is added to, of size ISIZE x N.
  * @param vectorA The first vector in the outer product, of length M.
  * @param vectorB The second vector in the outer product, of length N.
  * @details Performs the operations @code dstMatrix[ i ][ j ] += vectorA[ i ] * vectorB[ j ] @endcode
  */
-template< std::ptrdiff_t N, std::ptrdiff_t M, typename DST_MATRIX, typename VECTOR_A, typename VECTOR_B >
+template< std::ptrdiff_t JSIZE, std::ptrdiff_t ISIZE, typename DST_MATRIX, typename VECTOR_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_add_AiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-               VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
-               VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                   VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
+                   VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( N > 0, "N must be greater than zero." );
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< N, M >( dstMatrix );
-  internal::checkSizes< N >( vectorA );
-  internal::checkSizes< M >( vectorB );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< JSIZE, ISIZE >( dstMatrix );
+  internal::checkSizes< JSIZE >( vectorA );
+  internal::checkSizes< ISIZE >( vectorB );
 
-  for( std::ptrdiff_t i = 0; i < N; ++i )
+  for( std::ptrdiff_t i = 0; i < JSIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < M; ++j )
+    for( std::ptrdiff_t j = 0; j < ISIZE; ++j )
     {
       dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + vectorA[ i ] * vectorB[ j ];
     }
@@ -807,32 +807,32 @@ void Rij_add_AiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Perform the matrix vector multiplication of @p matrixA and @p vectorB writing the result to @p dstVector.
- * @tparam M The length of @p dstVector and the size of the first dimension of @p matrixA.
- * @tparam N The size of the second dimension of @p matrixA and the length of @p vectorBB.
+ * @tparam ISIZE The length of @p dstVector and the size of the first dimension of @p matrixA.
+ * @tparam JSIZE The size of the second dimension of @p matrixA and the length of @p vectorBB.
  * @tparam DST_VECTOR The type of @p dstVector.
  * @tparam MATRIX_A The type of @p matrixA.
  * @tparam VECTOR_B The type of @p vectorB.
  * @param dstVector The vector to write the result to, of length M.
- * @param matrixA The matrix to multiply @p vectorB by, of size M x N.
+ * @param matrixA The matrix to multiply @p vectorB by, of size ISIZE x N.
  * @param vectorB The vector multiplied by @p matrixA, of length N.
  * @details Performs the operations @code dstVector[ i ] = matrixA[ i ][ j ] * vectorB[ j ] @endcode
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Ri_eq_AijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
-            MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-            VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                  MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                  VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "N must be greater than zero." );
-  internal::checkSizes< M >( dstVector );
-  internal::checkSizes< M, N >( matrixA );
-  internal::checkSizes< N >( vectorB );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  internal::checkSizes< ISIZE >( dstVector );
+  internal::checkSizes< ISIZE, JSIZE >( matrixA );
+  internal::checkSizes< JSIZE >( vectorB );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     dstVector[ i ] = matrixA[ i ][ 0 ] * vectorB[ 0 ];
-    for( std::ptrdiff_t j = 1; j < N; ++j )
+    for( std::ptrdiff_t j = 1; j < JSIZE; ++j )
     {
       dstVector[ i ] = dstVector[ i ] + matrixA[ i ][ j ] * vectorB[ j ];
     }
@@ -841,31 +841,31 @@ void Ri_eq_AijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
 /**
  * @brief Perform the matrix vector multiplication of @p matrixA and @p vectorB adding the result to @p dstVector.
- * @tparam M The length of @p dstVector and the size of the first dimension of @p matrixA.
- * @tparam N The size of the second dimension of @p matrixA and the length of @p vectorBB.
+ * @tparam ISIZE The length of @p dstVector and the size of the first dimension of @p matrixA.
+ * @tparam JSIZE The size of the second dimension of @p matrixA and the length of @p vectorBB.
  * @tparam DST_VECTOR The type of @p dstVector.
  * @tparam MATRIX_A The type of @p matrixA.
  * @tparam VECTOR_B The type of @p vectorB.
  * @param dstVector The vector to add the result to, of length M.
- * @param matrixA The matrix to multiply @p vectorB by, of size M x N.
+ * @param matrixA The matrix to multiply @p vectorB by, of size ISIZE x N.
  * @param vectorB The vector multiplied by @p matrixA, of length N.
  * @details Performs the operations @code dstVector[ i ] += matrixA[ i ][ j ] * vectorB[ j ] @endcode
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Ri_add_AijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
-                MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-                VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                   MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                   VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "M must be greater than zero." );
-  internal::checkSizes< M >( dstVector );
-  internal::checkSizes< M, N >( matrixA );
-  internal::checkSizes< N >( vectorB );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE >( dstVector );
+  internal::checkSizes< ISIZE, JSIZE >( matrixA );
+  internal::checkSizes< JSIZE >( vectorB );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
       dstVector[ i ] = dstVector[ i ] + matrixA[ i ][ j ] * vectorB[ j ];
     }
@@ -875,32 +875,32 @@ void Ri_add_AijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 /**
  * @brief Perform the matrix vector multiplication of the transpose of @p matrixA and @p vectorB
  *   writing the result to @p dstVector.
- * @tparam M The length of @p dstVector and the size of the second dimension of @p matrixA.
- * @tparam N The size of the first dimension of @p matrixA and the length of @p vectorB.
+ * @tparam ISIZE The length of @p dstVector and the size of the second dimension of @p matrixA.
+ * @tparam JSIZE The size of the first dimension of @p matrixA and the length of @p vectorB.
  * @tparam DST_VECTOR The type of @p dstVector.
  * @tparam MATRIX_A The type of @p matrixA.
  * @tparam VECTOR_B The type of @p vectorB.
  * @param dstVector The vector to write the result to, of length M.
- * @param matrixA The matrix to multiply @p vectorB by, of size N x M.
+ * @param matrixA The matrix to multiply @p vectorB by, of size JSIZE x M.
  * @param vectorB The vector multiplied by @p matrixA, of length N.
  * @details Performs the operations @code dstVector[ i ] = matrixA[ j ][ i ] * vectorB[ j ] @endcode
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Ri_eq_AjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
-            MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-            VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                  MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                  VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "N must be greater than zero." );
-  internal::checkSizes< M >( dstVector );
-  internal::checkSizes< N, M >( matrixA );
-  internal::checkSizes< N >( vectorB );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  internal::checkSizes< ISIZE >( dstVector );
+  internal::checkSizes< JSIZE, ISIZE >( matrixA );
+  internal::checkSizes< JSIZE >( vectorB );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     dstVector[ i ] = matrixA[ 0 ][ i ] * vectorB[ 0 ];
-    for( std::ptrdiff_t j = 1; j < N; ++j )
+    for( std::ptrdiff_t j = 1; j < JSIZE; ++j )
     {
       dstVector[ i ] = dstVector[ i ] + matrixA[ j ][ i ] * vectorB[ j ];
     }
@@ -910,31 +910,31 @@ void Ri_eq_AjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 /**
  * @brief Perform the matrix vector multiplication of the transpose of @p matrixA and @p vectorB
  *   adding the result to @p dstVector.
- * @tparam M The length of @p dstVector and the size of the second dimension of @p matrixA.
- * @tparam N The size of the first dimension of @p matrixA and the length of @p vectorB.
+ * @tparam ISIZE The length of @p dstVector and the size of the second dimension of @p matrixA.
+ * @tparam JSIZE The size of the first dimension of @p matrixA and the length of @p vectorB.
  * @tparam DST_VECTOR The type of @p dstVector.
  * @tparam MATRIX_A The type of @p matrixA.
  * @tparam VECTOR_B The type of @p vectorB.
  * @param dstVector The vector to add the result to, of length M.
- * @param matrixA The matrix to multiply @p vectorB by, of size N x M.
+ * @param matrixA The matrix to multiply @p vectorB by, of size JSIZE x M.
  * @param vectorB The vector multiplied by @p matrixA, of length N.
  * @details Performs the operations @code dstVector[ i ] += matrixA[ j ][ i ] * vectorB[ j ] @endcode
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Ri_add_AjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
-                MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-                VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
+                   MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                   VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "N must be greater than zero." );
-  internal::checkSizes< M >( dstVector );
-  internal::checkSizes< N, M >( matrixA );
-  internal::checkSizes< N >( vectorB );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  internal::checkSizes< ISIZE >( dstVector );
+  internal::checkSizes< JSIZE, ISIZE >( matrixA );
+  internal::checkSizes< JSIZE >( vectorB );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
       dstVector[ i ] = dstVector[ i ] + matrixA[ j ][ i ] * vectorB[ j ];
     }
@@ -951,26 +951,26 @@ void Ri_add_AjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
 /**
  * @brief Store the transpose of the NxM matrix @p srcMatrix in @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and the second dimension of @p srcMatrix.
- * @tparam N The size of the second dimension of @p dstMatrix and the first dimension of @p srcMatrix.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and the second dimension of @p srcMatrix.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and the first dimension of @p srcMatrix.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam SRC_MATRIX The type of @p srcMatrix.
  * @param dstMatrix The MxN matrix where the transpose of @p srcMatrix is written.
  * @param srcMatrix The NxM matrix to transpose.
  */
-template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_MATRIX, typename SRC_MATRIX >
+template< std::ptrdiff_t ISIZE, std::ptrdiff_t JSIZE, typename DST_MATRIX, typename SRC_MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void transpose( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                 SRC_MATRIX const & LVARRAY_RESTRICT_REF srcMatrix )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "M must be greater than zero." );
-  internal::checkSizes< M, N >( dstMatrix );
-  internal::checkSizes< N, M >( srcMatrix );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
+  internal::checkSizes< JSIZE, ISIZE >( srcMatrix );
 
-  for( std::ptrdiff_t i = 0; i < N; ++i )
+  for( std::ptrdiff_t i = 0; i < JSIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < M; ++j )
+    for( std::ptrdiff_t j = 0; j < ISIZE; ++j )
     {
       dstMatrix[ j ][ i ] = srcMatrix[ i ][ j ];
     }
@@ -979,43 +979,43 @@ void transpose( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Multiply @p matrixA with @p matrixB and put the result into @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and @p matrixA.
- * @tparam N The size of the second dimension of @p dstMatrix and @p matrixB.
- * @tparam P The size of the second dimension of @p matrixA and first dimension of @p matrixB.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and @p matrixA.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and @p matrixB.
+ * @tparam KSIZE The size of the second dimension of @p matrixA and first dimension of @p matrixB.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam MATRIX_A The type of @p matrixA.
  * @tparam MATRIX_B The type of @p matrixB.
- * @param dstMatrix The matrix the result is written to, of size M x N.
- * @param matrixA The left matrix in the multiplication, of size M x P.
- * @param matrixB The right matrix in the multiplication, of size P x N.
+ * @param dstMatrix The matrix the result is written to, of size ISIZE x N.
+ * @param matrixA The left matrix in the multiplication, of size ISIZE x P.
+ * @param matrixB The right matrix in the multiplication, of size KSIZE x N.
  * @details Performs the operation
  *   @code dstMatrix[ i ][ j ] = matrixA[ i ][ k ] * matrixB[ k ][ j ] @endcode
  */
-template< std::ptrdiff_t M,
-          std::ptrdiff_t N,
-          std::ptrdiff_t P,
+template< std::ptrdiff_t ISIZE,
+          std::ptrdiff_t JSIZE,
+          std::ptrdiff_t KSIZE,
           typename DST_MATRIX,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_eq_AikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-             MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-             MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
+                    MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                    MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( N > 0, "M must be greater than zero." );
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( P > 0, "P must be greater than zero." );
-  internal::checkSizes< M, N >( dstMatrix );
-  internal::checkSizes< M, P >( matrixA );
-  internal::checkSizes< P, N >( matrixB );
+  static_assert( JSIZE > 0, "M must be greater than zero." );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( KSIZE > 0, "P must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
+  internal::checkSizes< ISIZE, KSIZE >( matrixA );
+  internal::checkSizes< KSIZE, JSIZE >( matrixB );
 
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
       dstMatrix[ i ][ j ] = matrixA[ i ][ 0 ] * matrixB[ 0 ][ j ];
-      for( std::ptrdiff_t k = 1; k < P; ++k )
+      for( std::ptrdiff_t k = 1; k < KSIZE; ++k )
       {
         dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ i ][ k ] * matrixB[ k ][ j ];
       }
@@ -1025,42 +1025,42 @@ void Rij_eq_AikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Multiply @p matrixA with @p matrixB and add the result to @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and @p matrixA.
- * @tparam N The size of the second dimension of @p dstMatrix and @p matrixB.
- * @tparam P The size of the second dimension of @p matrixA and first dimension of @p matrixB.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and @p matrixA.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and @p matrixB.
+ * @tparam KSIZE The size of the second dimension of @p matrixA and first dimension of @p matrixB.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam MATRIX_A The type of @p matrixA.
  * @tparam MATRIX_B The type of @p matrixB.
- * @param dstMatrix The matrix the result is added to, of size M x N.
- * @param matrixA The left matrix in the multiplication, of size M x P.
- * @param matrixB The right matrix in the multiplication, of size P x N.
+ * @param dstMatrix The matrix the result is added to, of size ISIZE x N.
+ * @param matrixA The left matrix in the multiplication, of size ISIZE x P.
+ * @param matrixB The right matrix in the multiplication, of size KSIZE x N.
  * @details Performs the operation
  *   @code dstMatrix[ i ][ j ] += matrixA[ i ][ k ] * matrixB[ k ][ j ] @endcode
  */
-template< std::ptrdiff_t M,
-          std::ptrdiff_t N,
-          std::ptrdiff_t P,
+template< std::ptrdiff_t ISIZE,
+          std::ptrdiff_t JSIZE,
+          std::ptrdiff_t KSIZE,
           typename DST_MATRIX,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_add_AikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-                 MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-                 MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
+                     MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                     MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "N must be greater than zero." );
-  static_assert( P > 0, "P must be greater than zero." );
-  internal::checkSizes< M, N >( dstMatrix );
-  internal::checkSizes< M, P >( matrixA );
-  internal::checkSizes< P, N >( matrixB );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( KSIZE > 0, "P must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
+  internal::checkSizes< ISIZE, KSIZE >( matrixA );
+  internal::checkSizes< KSIZE, JSIZE >( matrixB );
 
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
-      for( std::ptrdiff_t k = 0; k < P; ++k )
+      for( std::ptrdiff_t k = 0; k < KSIZE; ++k )
       {
         dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ i ][ k ] * matrixB[ k ][ j ];
       }
@@ -1070,43 +1070,43 @@ void Rij_add_AikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Multiply @p matrixA with the transpose of @p matrixB and put the result into @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and @p matrixA.
- * @tparam N The size of the second dimension of @p dstMatrix and the first dimension of @p matrixB.
- * @tparam P The size of the second dimension of @p matrixA and @p matrixB.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and @p matrixA.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and the first dimension of @p matrixB.
+ * @tparam KSIZE The size of the second dimension of @p matrixA and @p matrixB.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam MATRIX_A The type of @p matrixA.
  * @tparam MATRIX_B The type of @p matrixB.
- * @param dstMatrix The matrix the result is written to, of size M x N.
- * @param matrixA The left matrix in the multiplication, of size M x P.
- * @param matrixB The right matrix in the multiplication, of size N x P.
+ * @param dstMatrix The matrix the result is written to, of size ISIZE x N.
+ * @param matrixA The left matrix in the multiplication, of size ISIZE x P.
+ * @param matrixB The right matrix in the multiplication, of size JSIZE x P.
  * @details Performs the operation
  *   @code dstMatrix[ i ][ j ] = matrixA[ i ][ k ] * matrixB[ j ][ k ] @endcode
  */
-template< std::ptrdiff_t M,
-          std::ptrdiff_t N,
-          std::ptrdiff_t P,
+template< std::ptrdiff_t ISIZE,
+          std::ptrdiff_t JSIZE,
+          std::ptrdiff_t KSIZE,
           typename DST_MATRIX,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_eq_AikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-             MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-             MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
+                    MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                    MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "M must be greater than zero." );
-  static_assert( P > 0, "P must be greater than zero." );
-  internal::checkSizes< M, N >( dstMatrix );
-  internal::checkSizes< M, P >( matrixA );
-  internal::checkSizes< N, P >( matrixB );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "M must be greater than zero." );
+  static_assert( KSIZE > 0, "P must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
+  internal::checkSizes< ISIZE, KSIZE >( matrixA );
+  internal::checkSizes< JSIZE, KSIZE >( matrixB );
 
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
       dstMatrix[ i ][ j ] = matrixA[ i ][ 0 ] * matrixB[ j ][ 0 ];
-      for( std::ptrdiff_t k = 1; k < P; ++k )
+      for( std::ptrdiff_t k = 1; k < KSIZE; ++k )
       {
         dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ i ][ k ] * matrixB[ j ][ k ];
       }
@@ -1116,41 +1116,41 @@ void Rij_eq_AikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Multiply @p matrixA with the transpose of @p matrixB and put the result into @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and @p matrixA.
- * @tparam N The size of the second dimension of @p dstMatrix and the first dimension of @p matrixB.
- * @tparam P The size of the second dimension of @p matrixA and @p matrixB.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and @p matrixA.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and the first dimension of @p matrixB.
+ * @tparam KSIZE The size of the second dimension of @p matrixA and @p matrixB.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam MATRIX_A The type of @p matrixA.
  * @tparam MATRIX_B The type of @p matrixB.
- * @param dstMatrix The matrix the result is written to, of size M x N.
- * @param matrixA The left matrix in the multiplication, of size M x P.
- * @param matrixB The right matrix in the multiplication, of size N x P.
+ * @param dstMatrix The matrix the result is written to, of size ISIZE x N.
+ * @param matrixA The left matrix in the multiplication, of size ISIZE x P.
+ * @param matrixB The right matrix in the multiplication, of size JSIZE x P.
  * @details Performs the operation
  *   @code dstMatrix[ i ][ j ] += matrixA[ i ][ k ] * matrixB[ j ][ k ] @endcode
  */
-template< std::ptrdiff_t M,
-          std::ptrdiff_t N,
-          std::ptrdiff_t P,
+template< std::ptrdiff_t ISIZE,
+          std::ptrdiff_t JSIZE,
+          std::ptrdiff_t KSIZE,
           typename DST_MATRIX,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_add_AikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-                 MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-                 MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
+                     MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                     MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "N must be greater than zero." );
-  static_assert( P > 0, "P must be greater than zero." );
-  internal::checkSizes< M, N >( dstMatrix );
-  internal::checkSizes< M, P >( matrixA );
-  internal::checkSizes< N, P >( matrixB );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  static_assert( KSIZE > 0, "P must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
+  internal::checkSizes< ISIZE, KSIZE >( matrixA );
+  internal::checkSizes< JSIZE, KSIZE >( matrixB );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
-      for( std::ptrdiff_t k = 0; k < P; ++k )
+      for( std::ptrdiff_t k = 0; k < KSIZE; ++k )
       {
         dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ i ][ k ] * matrixB[ j ][ k ];
       }
@@ -1160,33 +1160,33 @@ void Rij_add_AikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Multiply @p matrixA with the transpose of itself and put the result into @p dstMatrix.
- * @tparam M The size of the first dimension of @p matrixA and both dimensions of @p dstMatrix.
- * @tparam N The size of the second dimension of matrixA.
+ * @tparam ISIZE The size of the first dimension of @p matrixA and both dimensions of @p dstMatrix.
+ * @tparam JSIZE The size of the second dimension of matrixA.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam MATRIX_A The type of @p matrixA.
- * @param dstMatrix The matrix the result is written to, of size M x M.
- * @param matrixA The matrix in the multiplication, of size M x N.
+ * @param dstMatrix The matrix the result is written to, of size ISIZE x M.
+ * @param matrixA The matrix in the multiplication, of size ISIZE x N.
  * @details Performs the operation
  *   @code dstMatrix[ i ][ j ] += matrixA[ i ][ k ] * matrixA[ j ][ k ] @endcode
  */
-template< std::ptrdiff_t M,
-          std::ptrdiff_t N,
+template< std::ptrdiff_t ISIZE,
+          std::ptrdiff_t JSIZE,
           typename DST_MATRIX,
           typename MATRIX_A >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_add_AikAjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-                 MATRIX_A const & LVARRAY_RESTRICT_REF matrixA )
+                     MATRIX_A const & LVARRAY_RESTRICT_REF matrixA )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "N must be greater than zero." );
-  internal::checkSizes< M, M >( dstMatrix );
-  internal::checkSizes< M, N >( matrixA );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "N must be greater than zero." );
+  internal::checkSizes< ISIZE, ISIZE >( dstMatrix );
+  internal::checkSizes< ISIZE, JSIZE >( matrixA );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < M; ++j )
+    for( std::ptrdiff_t j = 0; j < ISIZE; ++j )
     {
-      for( std::ptrdiff_t k = 0; k < N; ++k )
+      for( std::ptrdiff_t k = 0; k < JSIZE; ++k )
       {
         dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ i ][ k ] * matrixA[ j ][ k ];
       }
@@ -1196,42 +1196,42 @@ void Rij_add_AikAjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Multiply the transpose of @p matrixA with @p matrixB and put the result into @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and the second dimension of @p matrixA.
- * @tparam N The size of the second dimension of @p dstMatrix and @p matrixB.
- * @tparam P The size of the first dimension of @p matrixA and @p matrixB.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and the second dimension of @p matrixA.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and @p matrixB.
+ * @tparam KSIZE The size of the first dimension of @p matrixA and @p matrixB.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam MATRIX_A The type of @p matrixA.
  * @tparam MATRIX_B The type of @p matrixB.
- * @param dstMatrix The matrix the result is written to, of size M x N.
- * @param matrixA The left matrix in the multiplication, of size P x M.
- * @param matrixB The right matrix in the multiplication, of size P x N.
+ * @param dstMatrix The matrix the result is written to, of size ISIZE x N.
+ * @param matrixA The left matrix in the multiplication, of size KSIZE x M.
+ * @param matrixB The right matrix in the multiplication, of size KSIZE x N.
  * @details Performs the operation
  *   @code dstMatrix[ i ][ j ] = matrixA[ k ][ i ] * matrixB[ k ][ j ] @endcode
  */
-template< std::ptrdiff_t M,
-          std::ptrdiff_t N,
-          std::ptrdiff_t P,
+template< std::ptrdiff_t ISIZE,
+          std::ptrdiff_t JSIZE,
+          std::ptrdiff_t KSIZE,
           typename DST_MATRIX,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_eq_AkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-             MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-             MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
+                    MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                    MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "M must be greater than zero." );
-  static_assert( P > 0, "P must be greater than zero." );
-  internal::checkSizes< M, N >( dstMatrix );
-  internal::checkSizes< P, M >( matrixA );
-  internal::checkSizes< P, N >( matrixB );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "M must be greater than zero." );
+  static_assert( KSIZE > 0, "P must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
+  internal::checkSizes< KSIZE, ISIZE >( matrixA );
+  internal::checkSizes< KSIZE, JSIZE >( matrixB );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
       dstMatrix[ i ][ j ] = matrixA[ 0 ][ i ] * matrixB[ 0 ][ j ];
-      for( std::ptrdiff_t k = 1; k < P; ++k )
+      for( std::ptrdiff_t k = 1; k < KSIZE; ++k )
       {
         dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ k ][ i ] * matrixB[ k ][ j ];
       }
@@ -1241,41 +1241,41 @@ void Rij_eq_AkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Multiply the transpose of @p matrixA with @p matrixB and add the result into @p dstMatrix.
- * @tparam M The size of the first dimension of @p dstMatrix and the second dimension of @p matrixA.
- * @tparam N The size of the second dimension of @p dstMatrix and @p matrixB.
- * @tparam P The size of the first dimension of @p matrixA and @p matrixB.
+ * @tparam ISIZE The size of the first dimension of @p dstMatrix and the second dimension of @p matrixA.
+ * @tparam JSIZE The size of the second dimension of @p dstMatrix and @p matrixB.
+ * @tparam KSIZE The size of the first dimension of @p matrixA and @p matrixB.
  * @tparam DST_MATRIX The type of @p dstMatrix.
  * @tparam MATRIX_A The type of @p matrixA.
  * @tparam MATRIX_B The type of @p matrixB.
- * @param dstMatrix The matrix the result is written to, of size M x N.
- * @param matrixA The left matrix in the multiplication, of size P x M.
- * @param matrixB The right matrix in the multiplication, of size P x N.
+ * @param dstMatrix The matrix the result is written to, of size ISIZE x N.
+ * @param matrixA The left matrix in the multiplication, of size KSIZE x M.
+ * @param matrixB The right matrix in the multiplication, of size KSIZE x N.
  * @details Performs the operation
  *   @code dstMatrix[ i ][ j ] += matrixA[ k ][ i ] * matrixB[ k ][ j ] @endcode
  */
-template< std::ptrdiff_t M,
-          std::ptrdiff_t N,
-          std::ptrdiff_t P,
+template< std::ptrdiff_t ISIZE,
+          std::ptrdiff_t JSIZE,
+          std::ptrdiff_t KSIZE,
           typename DST_MATRIX,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void Rij_add_AkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
-                 MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
-                 MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
+                     MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
+                     MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  static_assert( N > 0, "M must be greater than zero." );
-  static_assert( P > 0, "P must be greater than zero." );
-  internal::checkSizes< M, N >( dstMatrix );
-  internal::checkSizes< P, M >( matrixA );
-  internal::checkSizes< P, N >( matrixB );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  static_assert( JSIZE > 0, "M must be greater than zero." );
+  static_assert( KSIZE > 0, "P must be greater than zero." );
+  internal::checkSizes< ISIZE, JSIZE >( dstMatrix );
+  internal::checkSizes< KSIZE, ISIZE >( matrixA );
+  internal::checkSizes< KSIZE, JSIZE >( matrixB );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = 0; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < JSIZE; ++j )
     {
-      for( std::ptrdiff_t k = 0; k < P; ++k )
+      for( std::ptrdiff_t k = 0; k < KSIZE; ++k )
       {
         dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ k ][ i ] * matrixB[ k ][ j ];
       }
@@ -1293,20 +1293,20 @@ void Rij_add_AkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
 
 /**
  * @brief Transpose the MxM matrix @p matrix.
- * @tparam M The size of @p matrix.
+ * @tparam ISIZE The size of @p matrix.
  * @tparam MATRIX The type of @p matrix.
  * @param matrix The MxM matrix to transpose.
  */
-template< std::ptrdiff_t M, typename MATRIX >
+template< std::ptrdiff_t ISIZE, typename MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void transpose( MATRIX && LVARRAY_RESTRICT_REF matrix )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M, M >( matrix );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE, ISIZE >( matrix );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
-    for( std::ptrdiff_t j = i + 1; j < M; ++j )
+    for( std::ptrdiff_t j = i + 1; j < ISIZE; ++j )
     {
       auto const entryIJ = matrix[ i ][ j ];
       matrix[ i ][ j ] = matrix[ j ][ i ];
@@ -1317,20 +1317,20 @@ void transpose( MATRIX && LVARRAY_RESTRICT_REF matrix )
 
 /**
  * @brief Add @p scale times the identity matrix to @p matrix.
- * @tparam M The size of @p matrix.
+ * @tparam ISIZE The size of @p matrix.
  * @tparam MATRIX The type of @p matrix.
- * @param matrix The M x M matrix to add the identity matrix to.
+ * @param matrix The ISIZE x ISIZE matrix to add the identity matrix to.
  * @param scale The amount to scale the identity matrix by.
  * @details Performs the operations @code matrix[ i ][ i ] += scale @endcode
  */
-template< std::ptrdiff_t M, typename MATRIX >
+template< std::ptrdiff_t ISIZE, typename MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void addIdentity( MATRIX && matrix, std::remove_reference_t< decltype( matrix[ 0 ][ 0 ] ) > const scale )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M, M >( matrix );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE, ISIZE >( matrix );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     matrix[ i ][ i ] += scale;
   }
@@ -1338,19 +1338,19 @@ void addIdentity( MATRIX && matrix, std::remove_reference_t< decltype( matrix[ 0
 
 /**
  * @return The trace of @p matrix.
- * @tparam M The size of @p matrix.
+ * @tparam ISIZE The size of @p matrix.
  * @tparam MATRIX The type of @p matrix.
- * @param matrix The M x M matrix to get the trace of.
+ * @param matrix The ISIZE x ISIZE matrix to get the trace of.
  */
-template< std::ptrdiff_t M, typename MATRIX >
+template< std::ptrdiff_t ISIZE, typename MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto trace( MATRIX const & matrix )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< M, M >( matrix );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< ISIZE, ISIZE >( matrix );
 
   auto trace = matrix[ 0 ][ 0 ];
-  for( std::ptrdiff_t i = 1; i < M; ++i )
+  for( std::ptrdiff_t i = 1; i < ISIZE; ++i )
   {
     trace += matrix[ i ][ i ];
   }
@@ -1368,20 +1368,20 @@ auto trace( MATRIX const & matrix )
 
 /**
  * @brief Add @p scale times the identity matrix to @p symMatrix.
- * @tparam M The size of @p symMatrix.
+ * @tparam ISIZE The size of @p symMatrix.
  * @tparam SYM_MATRIX The type of @p symMatrix.
- * @param symMatrix The M x M symmetric matrix to add the identity matrix to.
+ * @param symMatrix The ISIZE x ISIZE symmetric matrix to add the identity matrix to.
  * @param scale The amount to scale the identity matrix by.
  * @details Performs the operations @code matrix[ i ][ i ] += scale @endcode
  */
-template< std::ptrdiff_t M, typename SYM_MATRIX >
+template< std::ptrdiff_t ISIZE, typename SYM_MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 void symAddIdentity( SYM_MATRIX && symMatrix, std::remove_reference_t< decltype( symMatrix[ 0 ] ) > const scale )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< SYM_SIZE< M > >( symMatrix );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< SYM_SIZE< ISIZE > >( symMatrix );
 
-  for( std::ptrdiff_t i = 0; i < M; ++i )
+  for( std::ptrdiff_t i = 0; i < ISIZE; ++i )
   {
     symMatrix[ i ] += scale;
   }
@@ -1389,19 +1389,19 @@ void symAddIdentity( SYM_MATRIX && symMatrix, std::remove_reference_t< decltype(
 
 /**
  * @return The trace of @p symMatrix.
- * @tparam M The size of @p symMatrix.
+ * @tparam ISIZE The size of @p symMatrix.
  * @tparam SYM_MATRIX The type of @p symMatrix.
- * @param symMatrix The M x M symmetric matrix to get the trace of.
+ * @param symMatrix The ISIZE x ISIZE symmetric matrix to get the trace of.
  */
-template< std::ptrdiff_t M, typename SYM_MATRIX >
+template< std::ptrdiff_t ISIZE, typename SYM_MATRIX >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
 auto symTrace( SYM_MATRIX const & symMatrix )
 {
-  static_assert( M > 0, "M must be greater than zero." );
-  internal::checkSizes< SYM_SIZE< M > >( symMatrix );
+  static_assert( ISIZE > 0, "M must be greater than zero." );
+  internal::checkSizes< SYM_SIZE< ISIZE > >( symMatrix );
 
   auto trace = symMatrix[ 0 ];
-  for( std::ptrdiff_t i = 1; i < M; ++i )
+  for( std::ptrdiff_t i = 1; i < ISIZE; ++i )
   {
     trace += symMatrix[ i ];
   }

--- a/src/genericTensorOps.hpp
+++ b/src/genericTensorOps.hpp
@@ -753,7 +753,7 @@ void crossProduct( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
  */
 template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_MATRIX, typename VECTOR_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void AiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+void Rij_eq_AiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
            VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
            VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
@@ -786,7 +786,7 @@ void AiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
  */
 template< std::ptrdiff_t N, std::ptrdiff_t M, typename DST_MATRIX, typename VECTOR_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void plusAiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+void Rij_add_AiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                VECTOR_A const & LVARRAY_RESTRICT_REF vectorA,
                VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
@@ -819,7 +819,7 @@ void plusAiBj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
  */
 template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void AijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
+void Ri_eq_AijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
             MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
             VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
@@ -853,7 +853,7 @@ void AijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
  */
 template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void plusAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
+void Ri_add_AijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                 MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                 VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
@@ -887,7 +887,7 @@ void plusAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
  */
 template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void AjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
+void Ri_eq_AjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
             MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
             VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
@@ -922,7 +922,7 @@ void AjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
  */
 template< std::ptrdiff_t M, std::ptrdiff_t N, typename DST_VECTOR, typename MATRIX_A, typename VECTOR_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void plusAjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
+void Ri_add_AjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
                 MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                 VECTOR_B const & LVARRAY_RESTRICT_REF vectorB )
 {
@@ -998,7 +998,7 @@ template< std::ptrdiff_t M,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void AikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+void Rij_eq_AikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
              MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
              MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
@@ -1044,7 +1044,7 @@ template< std::ptrdiff_t M,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void plusAikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+void Rij_add_AikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                  MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                  MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
@@ -1089,7 +1089,7 @@ template< std::ptrdiff_t M,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void AikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+void Rij_eq_AikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
              MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
              MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
@@ -1135,7 +1135,7 @@ template< std::ptrdiff_t M,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void plusAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+void Rij_add_AikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                  MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                  MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
@@ -1174,7 +1174,7 @@ template< std::ptrdiff_t M,
           typename DST_MATRIX,
           typename MATRIX_A >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void plusAikAjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+void Rij_add_AikAjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                  MATRIX_A const & LVARRAY_RESTRICT_REF matrixA )
 {
   static_assert( M > 0, "M must be greater than zero." );
@@ -1215,7 +1215,7 @@ template< std::ptrdiff_t M,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void AkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+void Rij_eq_AkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
              MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
              MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {
@@ -1260,7 +1260,7 @@ template< std::ptrdiff_t M,
           typename MATRIX_A,
           typename MATRIX_B >
 LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-void plusAkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
+void Rij_add_AkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
                  MATRIX_A const & LVARRAY_RESTRICT_REF matrixA,
                  MATRIX_B const & LVARRAY_RESTRICT_REF matrixB )
 {

--- a/src/genericTensorOps.hpp
+++ b/src/genericTensorOps.hpp
@@ -831,13 +831,11 @@ void AijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
   for( std::ptrdiff_t i = 0; i < M; ++i )
   {
-    auto dot = matrixA[ i ][ 0 ] * vectorB[ 0 ];
+    dstVector[ i ] = matrixA[ i ][ 0 ] * vectorB[ 0 ];
     for( std::ptrdiff_t j = 1; j < N; ++j )
     {
-      dot = dot + matrixA[ i ][ j ] * vectorB[ j ];
+      dstVector[ i ] = dstVector[ i ] + matrixA[ i ][ j ] * vectorB[ j ];
     }
-
-    dstVector[ i ] = dot;
   }
 }
 
@@ -867,13 +865,10 @@ void plusAijBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
   for( std::ptrdiff_t i = 0; i < M; ++i )
   {
-    auto dot = matrixA[ i ][ 0 ] * vectorB[ 0 ];
-    for( std::ptrdiff_t j = 1; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < N; ++j )
     {
-      dot = dot + matrixA[ i ][ j ] * vectorB[ j ];
+      dstVector[ i ] = dstVector[ i ] + matrixA[ i ][ j ] * vectorB[ j ];
     }
-
-    dstVector[ i ] += dot;
   }
 }
 
@@ -904,13 +899,11 @@ void AjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
   for( std::ptrdiff_t i = 0; i < M; ++i )
   {
-    auto dot = matrixA[ 0 ][ i ] * vectorB[ 0 ];
+    dstVector[ i ] = matrixA[ 0 ][ i ] * vectorB[ 0 ];
     for( std::ptrdiff_t j = 1; j < N; ++j )
     {
-      dot = dot + matrixA[ j ][ i ] * vectorB[ j ];
+      dstVector[ i ] = dstVector[ i ] + matrixA[ j ][ i ] * vectorB[ j ];
     }
-
-    dstVector[ i ] = dot;
   }
 }
 
@@ -941,13 +934,10 @@ void plusAjiBj( DST_VECTOR && LVARRAY_RESTRICT_REF dstVector,
 
   for( std::ptrdiff_t i = 0; i < M; ++i )
   {
-    auto dot = matrixA[ 0 ][ i ] * vectorB[ 0 ];
-    for( std::ptrdiff_t j = 1; j < N; ++j )
+    for( std::ptrdiff_t j = 0; j < N; ++j )
     {
-      dot = dot + matrixA[ j ][ i ] * vectorB[ j ];
+      dstVector[ i ] = dstVector[ i ] + matrixA[ j ][ i ] * vectorB[ j ];
     }
-
-    dstVector[ i ] += dot;
   }
 }
 
@@ -1024,13 +1014,11 @@ void AikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
   {
     for( std::ptrdiff_t j = 0; j < N; ++j )
     {
-      auto dot = matrixA[ i ][ 0 ] * matrixB[ 0 ][ j ];
+      dstMatrix[ i ][ j ] = matrixA[ i ][ 0 ] * matrixB[ 0 ][ j ];
       for( std::ptrdiff_t k = 1; k < P; ++k )
       {
-        dot = dot + matrixA[ i ][ k ] * matrixB[ k ][ j ];
+        dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ i ][ k ] * matrixB[ k ][ j ];
       }
-
-      dstMatrix[ i ][ j ] = dot;
     }
   }
 }
@@ -1072,13 +1060,10 @@ void plusAikBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
   {
     for( std::ptrdiff_t j = 0; j < N; ++j )
     {
-      auto dot = matrixA[ i ][ 0 ] * matrixB[ 0 ][ j ];
-      for( std::ptrdiff_t k = 1; k < P; ++k )
+      for( std::ptrdiff_t k = 0; k < P; ++k )
       {
-        dot = dot + matrixA[ i ][ k ] * matrixB[ k ][ j ];
+        dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ i ][ k ] * matrixB[ k ][ j ];
       }
-
-      dstMatrix[ i ][ j ] += dot;
     }
   }
 }
@@ -1120,13 +1105,11 @@ void AikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
   {
     for( std::ptrdiff_t j = 0; j < N; ++j )
     {
-      auto dot = matrixA[ i ][ 0 ] * matrixB[ j ][ 0 ];
+      dstMatrix[ i ][ j ] = matrixA[ i ][ 0 ] * matrixB[ j ][ 0 ];
       for( std::ptrdiff_t k = 1; k < P; ++k )
       {
-        dot = dot + matrixA[ i ][ k ] * matrixB[ j ][ k ];
+        dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ i ][ k ] * matrixB[ j ][ k ];
       }
-
-      dstMatrix[ i ][ j ] = dot;
     }
   }
 }
@@ -1167,13 +1150,10 @@ void plusAikBjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
   {
     for( std::ptrdiff_t j = 0; j < N; ++j )
     {
-      auto dot = matrixA[ i ][ 0 ] * matrixB[ j ][ 0 ];
-      for( std::ptrdiff_t k = 1; k < P; ++k )
+      for( std::ptrdiff_t k = 0; k < P; ++k )
       {
-        dot = dot + matrixA[ i ][ k ] * matrixB[ j ][ k ];
+        dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ i ][ k ] * matrixB[ j ][ k ];
       }
-
-      dstMatrix[ i ][ j ] += dot;
     }
   }
 }
@@ -1206,13 +1186,10 @@ void plusAikAjk( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
   {
     for( std::ptrdiff_t j = 0; j < M; ++j )
     {
-      auto dot = matrixA[ i ][ 0 ] * matrixA[ j ][ 0 ];
-      for( std::ptrdiff_t k = 1; k < N; ++k )
+      for( std::ptrdiff_t k = 0; k < N; ++k )
       {
-        dot = dot + matrixA[ i ][ k ] * matrixA[ j ][ k ];
+        dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ i ][ k ] * matrixA[ j ][ k ];
       }
-
-      dstMatrix[ i ][ j ] += dot;
     }
   }
 }
@@ -1253,13 +1230,11 @@ void AkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
   {
     for( std::ptrdiff_t j = 0; j < N; ++j )
     {
-      auto dot = matrixA[ 0 ][ i ] * matrixB[ 0 ][ j ];
+      dstMatrix[ i ][ j ] = matrixA[ 0 ][ i ] * matrixB[ 0 ][ j ];
       for( std::ptrdiff_t k = 1; k < P; ++k )
       {
-        dot = dot + matrixA[ k ][ i ] * matrixB[ k ][ j ];
+        dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ k ][ i ] * matrixB[ k ][ j ];
       }
-
-      dstMatrix[ i ][ j ] = dot;
     }
   }
 }
@@ -1300,13 +1275,10 @@ void plusAkiBkj( DST_MATRIX && LVARRAY_RESTRICT_REF dstMatrix,
   {
     for( std::ptrdiff_t j = 0; j < N; ++j )
     {
-      auto dot = matrixA[ 0 ][ i ] * matrixB[ 0 ][ j ];
-      for( std::ptrdiff_t k = 1; k < P; ++k )
+      for( std::ptrdiff_t k = 0; k < P; ++k )
       {
-        dot = dot + matrixA[ k ][ i ] * matrixB[ k ][ j ];
+        dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + matrixA[ k ][ i ] * matrixB[ k ][ j ];
       }
-
-      dstMatrix[ i ][ j ] = dstMatrix[ i ][ j ] + dot;
     }
   }
 }

--- a/unitTests/testTensorOpsEigen.cpp
+++ b/unitTests/testTensorOpsEigen.cpp
@@ -133,7 +133,7 @@ public:
 
         // Check that the matrix scales the eigenvector by the eigenvalue.
         FLOAT output[ M ];
-        tensorOps::symAijBj< M >( output, matrices[ i ], eigenvectors[ i ][ j ] );
+        tensorOps::Ri_eq_symAijBj< M >( output, matrices[ i ], eigenvectors[ i ][ j ] );
 
         double diff = 0;
         for( int k = 0; k < M; ++k )
@@ -199,7 +199,7 @@ public:
       // Construct Q from the eigenvectors.
       FLOAT Q[ M ][ M ];
       tensorOps::transpose< M, M >( Q, eigenvectors[ i ] );
-      tensorOps::AikSymBklAjl< M >( matrices[ i ], Q, lambda );
+      tensorOps::Rij_eq_AikSymBklAjl< M >( matrices[ i ], Q, lambda );
     } );
   }
 

--- a/unitTests/testTensorOpsFixedSize.cpp
+++ b/unitTests/testTensorOpsFixedSize.cpp
@@ -66,7 +66,7 @@ public:
     {
       T denseSymA[ N ][ N ];
       tensorOps::symmetricToDense< N >( denseSymA, m_symMatrixA_local );
-      tensorOps::AijBj< N, N >( result, denseSymA, m_vectorB_local );
+      tensorOps::Ri_eq_AijBj< N, N >( result, denseSymA, m_vectorB_local );
     }
 
     ArrayViewT< T, 2, 1 > const vectorA_IJ = m_vectorA_IJ.toView();
@@ -87,7 +87,7 @@ public:
         {
           #define _TEST( vectorA, symMatrix, vectorB ) \
             fill( vectorA, vectorASeed ); \
-            tensorOps::symAijBj< N >( vectorA, symMatrix, vectorB ); \
+            tensorOps::Ri_eq_symAijBj< N >( vectorA, symMatrix, vectorB ); \
             CHECK_EQUALITY_1D( N, vectorA, result )
 
           #define _TEST_PERMS( vectorA, symMatrix, vectorB0, vectorB1, vectorB2 ) \
@@ -114,14 +114,14 @@ public:
         } );
   }
 
-  void plusSymAijBj()
+  void Ri_add_symAijBj()
   {
     T result[ N ];
     tensorOps::copy< N >( result, m_vectorA_local );
     {
       T denseSymA[ N ][ N ];
       tensorOps::symmetricToDense< N >( denseSymA, m_symMatrixA_local );
-      tensorOps::plusAijBj< N, N >( result, denseSymA, m_vectorB_local );
+      tensorOps::Ri_add_AijBj< N, N >( result, denseSymA, m_vectorB_local );
     }
 
     ArrayViewT< T, 2, 1 > const vectorA_IJ = m_vectorA_IJ.toView();
@@ -142,7 +142,7 @@ public:
         {
           #define _TEST( vectorA, symMatrix, vectorB ) \
             fill( vectorA, vectorASeed ); \
-            tensorOps::plusSymAijBj< N >( vectorA, symMatrix, vectorB ); \
+            tensorOps::Ri_add_symAijBj< N >( vectorA, symMatrix, vectorB ); \
             CHECK_EQUALITY_1D( N, vectorA, result )
 
           #define _TEST_PERMS( vectorA, symMatrix, vectorB0, vectorB1, vectorB2 ) \
@@ -175,7 +175,7 @@ public:
     {
       T denseSymA[ N ][ N ];
       tensorOps::symmetricToDense< N >( denseSymA, m_symMatrixA_local );
-      tensorOps::AikBjk< N, N, N >( result, denseSymA, m_matrixB_local );
+      tensorOps::Rij_eq_AikBjk< N, N, N >( result, denseSymA, m_matrixB_local );
     }
 
     ArrayViewT< T, 3, 2 > const matrixA_IJK = m_matrixA_IJK.toView();
@@ -200,7 +200,7 @@ public:
         {
           #define _TEST( matrixA, symMatrix, matrixB ) \
             fill( matrixA, matrixASeed ); \
-            tensorOps::symAikBjk< N >( matrixA, symMatrix, matrixB ); \
+            tensorOps::Rij_eq_symAikBjk< N >( matrixA, symMatrix, matrixB ); \
             CHECK_EQUALITY_2D( N, N, matrixA, result )
 
           #define _TEST_PERMS( matrixA, symMatrix, matrixB0, matrixB1, matrixB2, matrixB3 ) \
@@ -229,7 +229,7 @@ public:
         } );
   }
 
-  void AikSymBklAjl()
+  void Rij_eq_AikSymBklAjl()
   {
     T result[ SYM_SIZE ];
     {
@@ -237,10 +237,10 @@ public:
       tensorOps::symmetricToDense< N >( denseSymB, m_symMatrixB_local );
 
       T temp[ N ][ N ];
-      tensorOps::AikBjk< N, N, N >( temp, denseSymB, m_matrixA_local );
+      tensorOps::Rij_eq_AikBjk< N, N, N >( temp, denseSymB, m_matrixA_local );
 
       T denseResult[ N ][ N ];
-      tensorOps::AikBkj< N, N, N >( denseResult, m_matrixA_local, temp );
+      tensorOps::Rij_eq_AikBkj< N, N, N >( denseResult, m_matrixA_local, temp );
       tensorOps::denseToSymmetric< N >( result, denseResult );
     }
 
@@ -265,7 +265,7 @@ public:
         {
           #define _TEST( symMatrixA, matrixA, symMatrixB ) \
             fill( symMatrixA, matrixASeed ); \
-            tensorOps::AikSymBklAjl< N >( symMatrixA, matrixA, symMatrixB ); \
+            tensorOps::Rij_eq_AikSymBklAjl< N >( symMatrixA, matrixA, symMatrixB ); \
             CHECK_EQUALITY_1D( SYM_SIZE, symMatrixA, result )
 
           #define _TEST_PERMS( matrixA, symMatrix, symMatrixB0, symMatrixB1, symMatrixB2 ) \
@@ -443,9 +443,9 @@ TYPED_TEST( FixedSizeSquareMatrixTest, symAijBj )
   this->symAijBj();
 }
 
-TYPED_TEST( FixedSizeSquareMatrixTest, plusSymAijBj )
+TYPED_TEST( FixedSizeSquareMatrixTest, Ri_add_symAijBj )
 {
-  this->plusSymAijBj();
+  this->Ri_add_symAijBj();
 }
 
 TYPED_TEST( FixedSizeSquareMatrixTest, symAikBjk )
@@ -453,9 +453,9 @@ TYPED_TEST( FixedSizeSquareMatrixTest, symAikBjk )
   this->symAikBjk();
 }
 
-TYPED_TEST( FixedSizeSquareMatrixTest, AikSymBklAjl )
+TYPED_TEST( FixedSizeSquareMatrixTest, Rij_eq_AikSymBklAjl )
 {
-  this->AikSymBklAjl();
+  this->Rij_eq_AikSymBklAjl();
 }
 
 TYPED_TEST( FixedSizeSquareMatrixTest, symmetricToDense )

--- a/unitTests/testTensorOpsInverse.hpp
+++ b/unitTests/testTensorOpsInverse.hpp
@@ -261,7 +261,7 @@ private:
     T copy[ M ][ M ];
     T result[ M ][ M ];
     tensorOps::copy< M, M >( copy, matrix );
-    tensorOps::AikBkj< M, M, M >( result, copy, matrix );
+    tensorOps::Rij_eq_AikBkj< M, M, M >( result, copy, matrix );
 
     PORTABLE_EXPECT_NEAR( originalDet * originalDet, tensorOps::determinant< M >( result ), 4 * epsilonScale6 );
 
@@ -311,7 +311,7 @@ private:
     PORTABLE_EXPECT_NEAR( 1.0 / det, tensorOps::determinant< M >( inverse ), scale * epsilon );
 
     FLOAT product[ M ][ M ];
-    tensorOps::AikBkj< M, M, M >( product, inverse, source );
+    tensorOps::Rij_eq_AikBkj< M, M, M >( product, inverse, source );
 
     for( int i = 0; i < M; ++i )
     {
@@ -338,7 +338,7 @@ private:
     tensorOps::symmetricToDense< M >( denseSource, source );
 
     FLOAT product[ M ][ M ];
-    tensorOps::AikBkj< M, M, M >( product, denseInverse, denseSource );
+    tensorOps::Rij_eq_AikBkj< M, M, M >( product, denseInverse, denseSource );
 
     for( int i = 0; i < M; ++i )
     {

--- a/unitTests/testTensorOpsThreeSizes.hpp
+++ b/unitTests/testTensorOpsThreeSizes.hpp
@@ -94,7 +94,7 @@ public:
         {
           #define _TEST( matrixNM, matrixML, matrixLM ) \
             fill( matrixNM, matrixNMSeed ); \
-            tensorOps::AikBkj< N, M, L >( matrixNM, matrixML, matrixLM ); \
+            tensorOps::Rij_eq_AikBkj< N, M, L >( matrixNM, matrixML, matrixLM ); \
             CHECK_EQUALITY_2D( N, M, matrixNM, result )
 
           #define _TEST_PERMS( matrixNM, matrixML, matrixLM0, matrixLM1, matrixLM2, matrixLM3 ) \
@@ -166,7 +166,7 @@ public:
         {
           #define _TEST( matrixNM, matrixML, matrixLM ) \
             fill( matrixNM, matrixNMSeed ); \
-            tensorOps::plusAikBkj< N, M, L >( matrixNM, matrixML, matrixLM ); \
+            tensorOps::Rij_add_AikBkj< N, M, L >( matrixNM, matrixML, matrixLM ); \
             CHECK_EQUALITY_2D( N, M, matrixNM, result )
 
           #define _TEST_PERMS( matrixNM, matrixML, matrixLM0, matrixLM1, matrixLM2, matrixLM3 ) \
@@ -238,7 +238,7 @@ public:
         {
           #define _TEST( matrixNM, matrixNL, matrixML ) \
             fill( matrixNM, matrixNMSeed ); \
-            tensorOps::AikBjk< N, M, L >( matrixNM, matrixNL, matrixML ); \
+            tensorOps::Rij_eq_AikBjk< N, M, L >( matrixNM, matrixNL, matrixML ); \
             CHECK_EQUALITY_2D( N, M, matrixNM, result )
 
           #define _TEST_PERMS( matrixNM, matrixNL, matrixML0, matrixML1, matrixML2, matrixML3 ) \
@@ -310,7 +310,7 @@ public:
         {
           #define _TEST( matrixNM, matrixNL, matrixML ) \
             fill( matrixNM, matrixNMSeed ); \
-            tensorOps::plusAikBjk< N, M, L >( matrixNM, matrixNL, matrixML ); \
+            tensorOps::Rij_add_AikBjk< N, M, L >( matrixNM, matrixNL, matrixML ); \
             CHECK_EQUALITY_2D( N, M, matrixNM, result )
 
           #define _TEST_PERMS( matrixNM, matrixNL, matrixML0, matrixML1, matrixML2, matrixML3 ) \
@@ -381,7 +381,7 @@ public:
         {
           #define _TEST( matrixML, matrixNM, matrixNL ) \
             fill( matrixML, matrixMLSeed ); \
-            tensorOps::AkiBkj< M, L, N >( matrixML, matrixNM, matrixNL ); \
+            tensorOps::Rij_eq_AkiBkj< M, L, N >( matrixML, matrixNM, matrixNL ); \
             CHECK_EQUALITY_2D( M, L, matrixML, result )
 
           #define _TEST_PERMS( matrixML, matrixNM, matrixNL0, matrixNL1, matrixNL2, matrixNL3 ) \
@@ -452,7 +452,7 @@ public:
         {
           #define _TEST( matrixML, matrixNM, matrixNL ) \
             fill( matrixML, matrixMLSeed ); \
-            tensorOps::plusAkiBkj< M, L, N >( matrixML, matrixNM, matrixNL ); \
+            tensorOps::Rij_add_AkiBkj< M, L, N >( matrixML, matrixNM, matrixNL ); \
             CHECK_EQUALITY_2D( M, L, matrixML, result )
 
           #define _TEST_PERMS( matrixML, matrixNM, matrixNL0, matrixNL1, matrixNL2, matrixNL3 ) \

--- a/unitTests/testTensorOpsThreeSizes2.cpp
+++ b/unitTests/testTensorOpsThreeSizes2.cpp
@@ -13,7 +13,7 @@ namespace LvArray
 namespace testing
 {
 
-TYPED_TEST( ThreeSizesTest, plusAikBkj )
+TYPED_TEST( ThreeSizesTest, Rij_add_AikBkj )
 {
   this->testPlusAikBkj();
 }

--- a/unitTests/testTensorOpsThreeSizes4.cpp
+++ b/unitTests/testTensorOpsThreeSizes4.cpp
@@ -13,7 +13,7 @@ namespace LvArray
 namespace testing
 {
 
-TYPED_TEST( ThreeSizesTest, plusAikBjk )
+TYPED_TEST( ThreeSizesTest, Rij_add_AkiBkj )
 {
   this->testPlusAikBjk();
 }

--- a/unitTests/testTensorOpsThreeSizes6.cpp
+++ b/unitTests/testTensorOpsThreeSizes6.cpp
@@ -13,7 +13,7 @@ namespace LvArray
 namespace testing
 {
 
-TYPED_TEST( ThreeSizesTest, plusAkiBkj )
+TYPED_TEST( ThreeSizesTest, Rij_add_AkiBkj )
 {
   this->testPlusAkiBkj();
 }

--- a/unitTests/testTensorOpsTwoSizes.hpp
+++ b/unitTests/testTensorOpsTwoSizes.hpp
@@ -178,7 +178,7 @@ public:
         {
           #define _TEST( matrix, vectorN, vectorM ) \
             fill( matrix, matrixSeed ); \
-            tensorOps::AiBj< N, M >( matrix, vectorN, vectorM ); \
+            tensorOps::Rij_eq_AiBj< N, M >( matrix, vectorN, vectorM ); \
             CHECK_EQUALITY_2D( N, M, matrix, result )
 
           #define _TEST_PERMS( matrix, vectorN, vectorM0, vectorM1, vectorM2 ) \
@@ -237,7 +237,7 @@ public:
         {
           #define _TEST( matrix, vectorN, vectorM ) \
             fill( matrix, matrixSeed ); \
-            tensorOps::plusAiBj< N, M >( matrix, vectorN, vectorM ); \
+            tensorOps::Rij_add_AiBj< N, M >( matrix, vectorN, vectorM ); \
             CHECK_EQUALITY_2D( N, M, matrix, result )
 
           #define _TEST_PERMS( matrix, vectorN, vectorM0, vectorM1, vectorM2 ) \
@@ -298,7 +298,7 @@ public:
         {
           #define _TEST( matrix, vectorN, vectorM ) \
             fill( vectorN, vectorNSeed ); \
-            tensorOps::AijBj< N, M >( vectorN, matrix, vectorM ); \
+            tensorOps::Ri_eq_AijBj< N, M >( vectorN, matrix, vectorM ); \
             CHECK_EQUALITY_1D( N, vectorN, result )
 
           #define _TEST_PERMS( matrix, vectorN, vectorM0, vectorM1, vectorM2 ) \
@@ -359,7 +359,7 @@ public:
         {
           #define _TEST( matrix, vectorN, vectorM ) \
             fill( vectorN, vectorNSeed ); \
-            tensorOps::plusAijBj< N, M >( vectorN, matrix, vectorM ); \
+            tensorOps::Ri_add_AijBj< N, M >( vectorN, matrix, vectorM ); \
             CHECK_EQUALITY_1D( N, vectorN, result )
 
           #define _TEST_PERMS( matrix, vectorN, vectorM0, vectorM1, vectorM2 ) \
@@ -420,7 +420,7 @@ public:
         {
           #define _TEST( matrix, vectorN, vectorM ) \
             fill( vectorM, vectorMSeed ); \
-            tensorOps::AjiBj< M, N >( vectorM, matrix, vectorN ); \
+            tensorOps::Ri_eq_AjiBj< M, N >( vectorM, matrix, vectorN ); \
             CHECK_EQUALITY_1D( M, vectorM, result )
 
           #define _TEST_PERMS( matrix, vectorN, vectorM0, vectorM1, vectorM2 ) \
@@ -481,7 +481,7 @@ public:
         {
           #define _TEST( matrix, vectorN, vectorM ) \
             fill( vectorM, vectorMSeed ); \
-            tensorOps::plusAjiBj< M, N >( vectorM, matrix, vectorN ); \
+            tensorOps::Ri_add_AjiBj< M, N >( vectorM, matrix, vectorN ); \
             CHECK_EQUALITY_1D( M, vectorM, result )
 
           #define _TEST_PERMS( matrix, vectorN, vectorM0, vectorM1, vectorM2 ) \
@@ -702,7 +702,7 @@ public:
         {
           #define _TEST( matrixNN, matrixA ) \
             fill( matrixNN, matrixNNSeed ); \
-            tensorOps::plusAikAjk< N, M >( matrixNN, matrixA ); \
+            tensorOps::Rij_add_AikAjk< N, M >( matrixNN, matrixA ); \
             CHECK_EQUALITY_2D( N, N, matrixNN, result )
 
           #define _TEST_PERMS( matrixNN, matrixA0, matrixA1, matrixA2, matrixA3 ) \

--- a/unitTests/testTensorOpsTwoSizes2.cpp
+++ b/unitTests/testTensorOpsTwoSizes2.cpp
@@ -13,7 +13,7 @@ namespace LvArray
 namespace testing
 {
 
-TYPED_TEST( TwoSizesTest, plusAiBj )
+TYPED_TEST( TwoSizesTest, Rij_add_AiBj )
 {
   this->testPlusAiBj();
 }
@@ -23,7 +23,7 @@ TYPED_TEST( TwoSizesTest, AijBj )
   this->testAijBj();
 }
 
-TYPED_TEST( TwoSizesTest, plusAijBj )
+TYPED_TEST( TwoSizesTest, Ri_add_AijBj )
 {
   this->testPlusAijBj();
 }

--- a/unitTests/testTensorOpsTwoSizes3.cpp
+++ b/unitTests/testTensorOpsTwoSizes3.cpp
@@ -13,12 +13,12 @@ namespace LvArray
 namespace testing
 {
 
-TYPED_TEST( TwoSizesTest, AjiBj )
+TYPED_TEST( TwoSizesTest, Ri_eq_AjiBj )
 {
   this->testAjiBj();
 }
 
-TYPED_TEST( TwoSizesTest, plusAjiBj )
+TYPED_TEST( TwoSizesTest, Ri_add_AjiBj )
 {
   this->testPlusAjiBj();
 }

--- a/unitTests/testTensorOpsTwoSizes4.cpp
+++ b/unitTests/testTensorOpsTwoSizes4.cpp
@@ -23,7 +23,7 @@ TYPED_TEST( TwoSizesTest, add )
   this->testAdd();
 }
 
-TYPED_TEST( TwoSizesTest, plusAikAjk )
+TYPED_TEST( TwoSizesTest, Rij_add_AikAjk )
 {
   this->testPlusAikAjk();
 }


### PR DESCRIPTION
Make the calls to tensor ops a little more explicit by including the RHS with indices. So for instance `AikBjk` becomes `Rij_eq_AikBjk`. 

This is motivated by some difficulties I had with using the ops. Of course we can just recognize that the result is always `Ri` or `Rij`, but it is better imo to be explicit. 

I also changed the name of the template parameters `M,N,P` to `ISIZE, JSIZE, KSIZE` respectively. 

Associated changes in GEOSX are in https://github.com/GEOSX/GEOSX/pull/1170