### PR TITLE
Corbett/rvalue toview

### DIFF
--- a/src/Array.hpp
+++ b/src/Array.hpp
@@ -71,11 +71,11 @@ public:
   using Permutation = PERMUTATION;
 
   /// Alias for the parent class.
-  using ParentClass = ArrayView< T,
-  NDIM,
-  typeManipulation::getStrideOneDimension( PERMUTATION {} ),
-  INDEX_TYPE,
-  BUFFER_TYPE >;
+  using ParentClass = ArrayView< T, NDIM, typeManipulation::getStrideOneDimension( Permutation {} ), INDEX_TYPE, BUFFER_TYPE >;
+
+  using ParentClass::USD;
+  using typename ParentClass::NestedViewType;
+  using typename ParentClass::NestedViewTypeConst;
 
   /**
    * @name Constructors, destructor and assignment operators.
@@ -182,6 +182,77 @@ public:
     }
 
     return *this;
+  }
+
+  ///@}
+
+  /**
+   * @name ArrayView and ArraySlice creation methods and user defined conversions.
+   */
+  ///@{
+
+  using ParentClass::toView;
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArrayView.
+   * @note This cannot be called on a rvalue since the @c ArrayView would
+   *   contain the buffer of the current @c Array that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  inline LVARRAY_HOST_DEVICE constexpr
+  ArrayView< T, NDIM, USD, INDEX_TYPE, BUFFER_TYPE > toView() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toView on a rvalue." );
+    return ArrayView< T, NDIM, USD, INDEX_TYPE, BUFFER_TYPE >();
+  }
+
+  using ParentClass::toViewConst;
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArrayView.
+   * @note This cannot be called on a rvalue since the @c ArrayView would
+   *   contain the buffer of the current @c Array that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  inline LVARRAY_HOST_DEVICE constexpr
+  ArrayView< T const, NDIM, USD, INDEX_TYPE, BUFFER_TYPE > toViewConst() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toViewConst on a rvalue." );
+    return ArrayView< T const, NDIM, USD, INDEX_TYPE, BUFFER_TYPE >();
+  }
+
+  using ParentClass::toNestedView;
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArrayView.
+   * @note This cannot be called on a rvalue since the @c ArrayView would
+   *   contain the buffer of the current @c Array that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  inline LVARRAY_HOST_DEVICE constexpr
+  NestedViewType toNestedView() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toViewNested on a rvalue." );
+    return NestedViewType();
+  }
+
+  using ParentClass::toNestedViewConst;
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArrayView.
+   * @note This cannot be called on a rvalue since the @c ArrayView would
+   *   contain the buffer of the current @c Array that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  inline LVARRAY_HOST_DEVICE constexpr
+  NestedViewTypeConst toNestedViewConst() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toViewNestedConst on a rvalue." );
+    return NestedViewTypeConst();
   }
 
   ///@}

--- a/src/ArrayOfArrays.hpp
+++ b/src/ArrayOfArrays.hpp
@@ -52,8 +52,8 @@ public:
    * @param defaultArrayCapacity the initial capacity of each array.
    */
   inline
-  ArrayOfArrays( INDEX_TYPE const numArrays=0, INDEX_TYPE const defaultArrayCapacity=0 ) LVARRAY_RESTRICT_THIS:
-    ParentClass()
+  ArrayOfArrays( INDEX_TYPE const numArrays=0, INDEX_TYPE const defaultArrayCapacity=0 ):
+    ParentClass( true )
   {
     resize( numArrays, defaultArrayCapacity );
     setName( "" );
@@ -65,7 +65,7 @@ public:
    */
   inline
   ArrayOfArrays( ArrayOfArrays const & src ):
-    ParentClass()
+    ParentClass( true )
   { *this = src; }
 
   /**
@@ -95,8 +95,23 @@ public:
    */
   constexpr inline
   ArrayOfArraysView< T, INDEX_TYPE const, false, BUFFER_TYPE >
-  toView() const LVARRAY_RESTRICT_THIS
+  toView() const &
   { return ParentClass::toView(); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArrayOfArraysView.
+   * @note This cannot be called on a rvalue since the @c ArrayOfArraysView would
+   *   contain the buffer of the current @c ArrayOfArrays that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  constexpr inline
+  ArrayOfArraysView< T, INDEX_TYPE const, false, BUFFER_TYPE >
+  toView() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toView on a rvalue." );
+    return ParentClass::toView();
+  }
 
   /**
    * @copydoc ParentClass::toViewConstSizes
@@ -106,8 +121,23 @@ public:
    */
   constexpr inline
   ArrayOfArraysView< T, INDEX_TYPE const, true, BUFFER_TYPE >
-  toViewConstSizes() const LVARRAY_RESTRICT_THIS
+  toViewConstSizes() const &
   { return ParentClass::toViewConstSizes(); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArrayOfArraysView.
+   * @note This cannot be called on a rvalue since the @c ArrayOfArraysView would
+   *   contain the buffer of the current @c ArrayOfArrays that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  constexpr inline
+  ArrayOfArraysView< T, INDEX_TYPE const, true, BUFFER_TYPE >
+  toViewConstSizes() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toViewConstSizes on a rvalue." );
+    return ParentClass::toViewConstSizes();
+  }
 
   /**
    * @copydoc ParentClass::toViewConst
@@ -117,8 +147,23 @@ public:
    */
   constexpr inline
   ArrayOfArraysView< T const, INDEX_TYPE const, true, BUFFER_TYPE >
-  toViewConst() const LVARRAY_RESTRICT_THIS
+  toViewConst() const &
   { return ParentClass::toViewConst(); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArrayOfArraysView.
+   * @note This cannot be called on a rvalue since the @c ArrayOfArraysView would
+   *   contain the buffer of the current @c ArrayOfArrays that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  constexpr inline
+  ArrayOfArraysView< T const, INDEX_TYPE const, true, BUFFER_TYPE >
+  toViewConst() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toViewConst on a rvalue." );
+    return ParentClass::toViewConst();
+  }
 
   ///@}
 
@@ -133,7 +178,7 @@ public:
    * @return *this.
    */
   inline
-  ArrayOfArrays & operator=( ArrayOfArrays const & src ) LVARRAY_RESTRICT_THIS
+  ArrayOfArrays & operator=( ArrayOfArrays const & src )
   {
     ParentClass::setEqualTo( src.m_numArrays,
                              src.m_offsets[ src.m_numArrays ],
@@ -183,7 +228,7 @@ public:
    *   IS_VALID_EXPRESSION and this fails with NVCC.
    */
   inline
-  INDEX_TYPE size() const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE size() const
   { return ParentClass::size(); }
 
   using ParentClass::sizeOfArray;
@@ -233,7 +278,7 @@ public:
    * @brief Append an array.
    * @param n the size of the array.
    */
-  void appendArray( INDEX_TYPE const n ) LVARRAY_RESTRICT_THIS
+  void appendArray( INDEX_TYPE const n )
   {
     LVARRAY_ASSERT( arrayManipulation::isPositive( n ) );
 
@@ -252,7 +297,7 @@ public:
    * @param last An iterator to the end of the array to append.
    */
   template< typename ITER >
-  void appendArray( ITER const first, ITER const last ) LVARRAY_RESTRICT_THIS
+  void appendArray( ITER const first, ITER const last )
   {
     INDEX_TYPE const maxOffset = this->m_offsets[ this->m_numArrays ];
     bufferManipulation::emplaceBack( this->m_offsets, this->m_numArrays + 1, maxOffset );
@@ -312,7 +357,7 @@ public:
    * @param args A variadic pack of arguments that are forwarded to construct the new value.
    */
   template< typename ... ARGS >
-  void emplaceBack( INDEX_TYPE const i, ARGS && ... args ) LVARRAY_RESTRICT_THIS
+  void emplaceBack( INDEX_TYPE const i, ARGS && ... args )
   {
     dynamicallyGrowArray( i, 1 );
     ParentClass::emplaceBack( i, std::forward< ARGS >( args )... );
@@ -326,7 +371,7 @@ public:
    * @param last An iterator to the end of the values to append.
    */
   template< typename ITER >
-  void appendToArray( INDEX_TYPE const i, ITER const first, ITER const last ) LVARRAY_RESTRICT_THIS
+  void appendToArray( INDEX_TYPE const i, ITER const first, ITER const last )
   {
     INDEX_TYPE const n = arrayManipulation::iterDistance( first, last );
     dynamicallyGrowArray( i, n );

--- a/src/ArrayOfArraysView.hpp
+++ b/src/ArrayOfArraysView.hpp
@@ -197,6 +197,12 @@ public:
   ///@{
 
   /**
+   * @brief A constructor to create an uninitialized ArrayOfArraysView.
+   * @note An uninitialized ArrayOfArraysView should not be used until it is assigned to.
+   */
+  ArrayOfArraysView() = default;
+
+  /**
    * @brief Default copy constructor.
    * @note The copy constructor will trigger the copy constructor for @tparam BUFFER_TYPE
    */
@@ -267,7 +273,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   ArrayOfArraysView< T, INDEX_TYPE const, CONST_SIZES, BUFFER_TYPE >
-  toView() const LVARRAY_RESTRICT_THIS
+  toView() const
   {
     return ArrayOfArraysView< T, INDEX_TYPE const, CONST_SIZES, BUFFER_TYPE >( size(),
                                                                                this->m_offsets,
@@ -280,7 +286,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   ArrayOfArraysView< T, INDEX_TYPE const, true, BUFFER_TYPE >
-  toViewConstSizes() const LVARRAY_RESTRICT_THIS
+  toViewConstSizes() const
   {
     return ArrayOfArraysView< T, INDEX_TYPE const, true, BUFFER_TYPE >( size(),
                                                                         this->m_offsets,
@@ -293,7 +299,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   ArrayOfArraysView< T const, INDEX_TYPE const, true, BUFFER_TYPE >
-  toViewConst() const LVARRAY_RESTRICT_THIS
+  toViewConst() const
   {
     return ArrayOfArraysView< T const, INDEX_TYPE const, true, BUFFER_TYPE >( size(),
                                                                               this->m_offsets,
@@ -312,7 +318,7 @@ public:
    * @return Return the number of arrays.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  INDEX_TYPE_NC size() const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC size() const
   { return m_numArrays; }
 
   /**
@@ -320,7 +326,7 @@ public:
    * @param i the array to query.
    */
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  INDEX_TYPE_NC sizeOfArray( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC sizeOfArray( INDEX_TYPE const i ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
     return m_sizes[ i ];
@@ -330,7 +336,7 @@ public:
    * @return Return the number of (zero length) arrays that can be stored before reallocation.
    */
   LVARRAY_HOST_DEVICE CONSTEXPR_WITH_NDEBUG inline
-  INDEX_TYPE_NC capacity() const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC capacity() const
   {
     LVARRAY_ASSERT( m_sizes.capacity() < m_offsets.capacity());
     return m_sizes.capacity();
@@ -341,7 +347,7 @@ public:
    * @param i the array to query.
    */
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  INDEX_TYPE_NC capacityOfArray( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC capacityOfArray( INDEX_TYPE const i ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
     return m_offsets[ i + 1 ] - m_offsets[ i ];
@@ -351,7 +357,7 @@ public:
    * @return Return the total number values that can be stored before reallocation.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  INDEX_TYPE_NC valueCapacity() const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC valueCapacity() const
   { return m_values.capacity(); }
 
   ///@}
@@ -366,7 +372,7 @@ public:
    * @param i the array to access.
    */
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  ArraySlice< T, 1, 0, INDEX_TYPE_NC > operator[]( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
+  ArraySlice< T, 1, 0, INDEX_TYPE_NC > operator[]( INDEX_TYPE const i ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
     return ArraySlice< T, 1, 0, INDEX_TYPE_NC >( m_values.data() + m_offsets[ i ], &m_sizes[ i ], nullptr );
@@ -378,7 +384,7 @@ public:
    * @param j the index within the array to access.
    */
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
-  T & operator()( INDEX_TYPE const i, INDEX_TYPE const j ) const LVARRAY_RESTRICT_THIS
+  T & operator()( INDEX_TYPE const i, INDEX_TYPE const j ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS2( i, j );
     return m_values[m_offsets[ i ] + j];
@@ -401,7 +407,7 @@ public:
    */
   template< typename ... ARGS >
   LVARRAY_HOST_DEVICE inline
-  void emplaceBack( INDEX_TYPE const i, ARGS && ... args ) const LVARRAY_RESTRICT_THIS
+  void emplaceBack( INDEX_TYPE const i, ARGS && ... args ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
     ARRAYOFARRAYS_CAPACITY_CHECK( i, 1 );
@@ -422,7 +428,7 @@ public:
    */
   template< typename POLICY, typename ... ARGS >
   LVARRAY_HOST_DEVICE inline
-  void emplaceBackAtomic( INDEX_TYPE const i, ARGS && ... args ) const LVARRAY_RESTRICT_THIS
+  void emplaceBackAtomic( INDEX_TYPE const i, ARGS && ... args ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
 
@@ -444,7 +450,7 @@ public:
    */
   template< typename ITER >
   LVARRAY_HOST_DEVICE inline
-  void appendToArray( INDEX_TYPE const i, ITER const first, ITER const last ) const LVARRAY_RESTRICT_THIS
+  void appendToArray( INDEX_TYPE const i, ITER const first, ITER const last ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
 
@@ -465,7 +471,7 @@ public:
    */
   template< typename ... ARGS >
   LVARRAY_HOST_DEVICE inline
-  void emplace( INDEX_TYPE const i, INDEX_TYPE const j, ARGS && ... args ) const LVARRAY_RESTRICT_THIS
+  void emplace( INDEX_TYPE const i, INDEX_TYPE const j, ARGS && ... args ) const
   {
     ARRAYOFARRAYS_CHECK_INSERT_BOUNDS2( i, j );
     ARRAYOFARRAYS_CAPACITY_CHECK( i, 1 );
@@ -490,7 +496,7 @@ public:
   void insertIntoArray( INDEX_TYPE const i,
                         INDEX_TYPE const j,
                         ITER const first,
-                        ITER const last ) const LVARRAY_RESTRICT_THIS
+                        ITER const last ) const
   {
     ARRAYOFARRAYS_CHECK_INSERT_BOUNDS2( i, j );
     INDEX_TYPE const n = arrayManipulation::iterDistance( first, last );
@@ -508,7 +514,7 @@ public:
    * @param n the number of values to erase.
    */
   LVARRAY_HOST_DEVICE inline
-  void eraseFromArray( INDEX_TYPE const i, INDEX_TYPE const j, INDEX_TYPE const n=1 ) const LVARRAY_RESTRICT_THIS
+  void eraseFromArray( INDEX_TYPE const i, INDEX_TYPE const j, INDEX_TYPE const n=1 ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS2( i, j );
 
@@ -564,9 +570,10 @@ protected:
   using PairOfBuffers = std::pair< BUFFER_TYPE< U > &, BUFFER_TYPE< U > const & >;
 
   /**
-   * @brief Default constructor.
+   * @brief Protected constructor to be used by parent classes.
+   * @note The unused boolean parameter is to distinguish this from the default constructor.
    */
-  ArrayOfArraysView():
+  ArrayOfArraysView( bool ):
     m_numArrays( 0 ),
     m_offsets( true ),
     m_sizes( true ),

--- a/src/ArrayOfArraysView.hpp
+++ b/src/ArrayOfArraysView.hpp
@@ -964,7 +964,7 @@ private:
 
     typeManipulation::forEachArg( [this, begin, end] ( auto & buffer )
     {
-      if( !std::is_trivially_destructible< decltype( buffer[ 0 ] ) >::value )
+      if( !std::is_trivially_destructible< std::remove_reference_t< decltype( buffer[ 0 ] ) > >::value )
       {
         buffer.move( MemorySpace::CPU, true );
         for( INDEX_TYPE i = begin; i < end; ++i )

--- a/src/ArrayOfSets.hpp
+++ b/src/ArrayOfSets.hpp
@@ -54,8 +54,8 @@ public:
    * @param defaultSetCapacity the initial capacity of each set.
    */
   inline
-  ArrayOfSets( INDEX_TYPE const nsets=0, INDEX_TYPE defaultSetCapacity=0 ) LVARRAY_RESTRICT_THIS:
-    ParentClass()
+  ArrayOfSets( INDEX_TYPE const nsets=0, INDEX_TYPE defaultSetCapacity=0 ):
+    ParentClass( true )
   {
     resize( nsets, defaultSetCapacity );
     setName( "" );
@@ -66,8 +66,8 @@ public:
    * @param src the ArrayOfSets to copy.
    */
   inline
-  ArrayOfSets( ArrayOfSets const & src ) LVARRAY_RESTRICT_THIS:
-    ParentClass()
+  ArrayOfSets( ArrayOfSets const & src ):
+    ParentClass( true )
   { *this = src; }
 
   /**
@@ -80,7 +80,7 @@ public:
    * @brief Destructor, frees the values, sizes and offsets Buffers.
    */
   inline
-  ~ArrayOfSets() LVARRAY_RESTRICT_THIS
+  ~ArrayOfSets()
   { ParentClass::free(); }
 
   ///@}
@@ -96,7 +96,7 @@ public:
    * @return *this.
    */
   inline
-  ArrayOfSets & operator=( ArrayOfSets const & src ) LVARRAY_RESTRICT_THIS
+  ArrayOfSets & operator=( ArrayOfSets const & src )
   {
     ParentClass::setEqualTo( src.m_numArrays,
                              src.m_offsets[ src.m_numArrays ],
@@ -127,7 +127,7 @@ public:
    */
   inline
   void assimilate( ArrayOfArrays< T, INDEX_TYPE, BUFFER_TYPE > && src,
-                   sortedArrayManipulation::Description const desc ) LVARRAY_RESTRICT_THIS
+                   sortedArrayManipulation::Description const desc )
   {
     ParentClass::free();
     ParentClass::assimilate( reinterpret_cast< ParentClass && >( src ) );
@@ -189,8 +189,23 @@ public:
    */
   constexpr inline
   ArrayOfSetsView< T, INDEX_TYPE const, BUFFER_TYPE >
-  toView() const LVARRAY_RESTRICT_THIS
+  toView() const &
   { return ParentClass::toView(); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArrayOfSetsView.
+   * @note This cannot be called on a rvalue since the @c ArrayOfSetsView would
+   *   contain the buffers of the current @c ArrayOfSets that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  constexpr inline
+  ArrayOfSetsView< T, INDEX_TYPE const, BUFFER_TYPE >
+  toView() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toView on a rvalue." );
+    return ParentClass::toView();
+  }
 
   /**
    * @copydoc ParentClass::toViewConst
@@ -200,8 +215,23 @@ public:
    */
   constexpr inline
   ArrayOfSetsView< T const, INDEX_TYPE const, BUFFER_TYPE >
-  toViewConst() const LVARRAY_RESTRICT_THIS
+  toViewConst() const &
   { return ParentClass::toViewConst(); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArrayOfSetsView.
+   * @note This cannot be called on a rvalue since the @c ArrayOfSetsView would
+   *   contain the buffers of the current @c ArrayOfSets that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  constexpr inline
+  ArrayOfSetsView< T const, INDEX_TYPE const, BUFFER_TYPE >
+  toViewConst() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toViewConst on a rvalue." );
+    return ParentClass::toViewConst();
+  }
 
   /**
    * @copydoc ParentClass::toArrayOfArraysView
@@ -211,8 +241,23 @@ public:
    */
   constexpr inline
   ArrayOfArraysView< T const, INDEX_TYPE const, true, BUFFER_TYPE >
-  toArrayOfArraysView() const LVARRAY_RESTRICT_THIS
+  toArrayOfArraysView() const &
   { return ParentClass::toArrayOfArraysView(); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArrayOfSetsView.
+   * @note This cannot be called on a rvalue since the @c ArrayOfArraysView would
+   *   contain the buffers of the current @c ArrayOfSets that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  constexpr inline
+  ArrayOfArraysView< T const, INDEX_TYPE const, true, BUFFER_TYPE >
+  toArrayOfArraysView() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toArrayOfArraysView on a rvalue." );
+    return ParentClass::toArrayOfArraysView();
+  }
 
   ///@}
 
@@ -228,7 +273,7 @@ public:
    *   IS_VALID_EXPRESSION and this fails with NVCC.
    */
   inline
-  INDEX_TYPE size() const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE size() const
   { return ParentClass::size(); }
 
   using ParentClass::sizeOfSet;
@@ -282,7 +327,7 @@ public:
    * @param setCapacity The capacity of the set.
    */
   inline
-  void appendSet( INDEX_TYPE const setCapacity=0 ) LVARRAY_RESTRICT_THIS
+  void appendSet( INDEX_TYPE const setCapacity=0 )
   {
     INDEX_TYPE const maxOffset = this->m_offsets[ this->m_numArrays ];
     bufferManipulation::emplaceBack( this->m_offsets, this->m_numArrays + 1, maxOffset );
@@ -298,7 +343,7 @@ public:
    * @param setCapacity The capacity of the set.
    */
   inline
-  void insertSet( INDEX_TYPE const i, INDEX_TYPE const setCapacity=0 ) LVARRAY_RESTRICT_THIS
+  void insertSet( INDEX_TYPE const i, INDEX_TYPE const setCapacity=0 )
   {
     ARRAYOFARRAYS_CHECK_INSERT_BOUNDS( i );
     LVARRAY_ASSERT( arrayManipulation::isPositive( setCapacity ) );
@@ -318,7 +363,7 @@ public:
    * @param i the position of the set to erase.
    */
   inline
-  void eraseSet( INDEX_TYPE const i ) LVARRAY_RESTRICT_THIS
+  void eraseSet( INDEX_TYPE const i )
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
 
@@ -342,7 +387,7 @@ public:
    * @return True iff the value was inserted (the set did not already contain the value).
    */
   inline
-  bool insertIntoSet( INDEX_TYPE const i, T const & val ) LVARRAY_RESTRICT_THIS
+  bool insertIntoSet( INDEX_TYPE const i, T const & val )
   { return ParentClass::insertIntoSetImpl( i, val, CallBacks( *this, i ) ); }
 
   /**
@@ -356,7 +401,7 @@ public:
    */
   template< typename ITER >
   inline
-  INDEX_TYPE insertIntoSet( INDEX_TYPE const i, ITER const first, ITER const last ) LVARRAY_RESTRICT_THIS
+  INDEX_TYPE insertIntoSet( INDEX_TYPE const i, ITER const first, ITER const last )
   { return ParentClass::insertIntoSetImpl( i, first, last, CallBacks( *this, i ) ); }
 
   /**
@@ -364,7 +409,7 @@ public:
    * @note This is not brought in with a @c using statement because it breaks doxygen.
    */
   LVARRAY_HOST_DEVICE inline
-  bool removeFromSet( INDEX_TYPE const i, T const & value ) const LVARRAY_RESTRICT_THIS
+  bool removeFromSet( INDEX_TYPE const i, T const & value ) const
   { return ParentClass::removeFromSet( i, value ); }
 
   /**
@@ -380,14 +425,14 @@ public:
    */
   template< typename ITER >
   LVARRAY_HOST_DEVICE inline
-  INDEX_TYPE removeFromSet( INDEX_TYPE const i, ITER const first, ITER const last ) const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE removeFromSet( INDEX_TYPE const i, ITER const first, ITER const last ) const
   { return ParentClass::removeFromSet( i, first, last ); }
 
   /**
    * @brief Clear a set.
    * @param i the index of the set to clear.
    */
-  void clearSet( INDEX_TYPE const i ) LVARRAY_RESTRICT_THIS
+  void clearSet( INDEX_TYPE const i )
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
 
@@ -403,7 +448,7 @@ public:
    * @param newCapacity the value to set the capacity of the set to.
    */
   inline
-  void setCapacityOfSet( INDEX_TYPE const i, INDEX_TYPE newCapacity ) LVARRAY_RESTRICT_THIS
+  void setCapacityOfSet( INDEX_TYPE const i, INDEX_TYPE newCapacity )
   { ParentClass::setCapacityOfArray( i, newCapacity ); }
 
   /**
@@ -412,7 +457,7 @@ public:
    * @param newCapacity the number of values to reserve space for.
    */
   inline
-  void reserveCapacityOfSet( INDEX_TYPE const i, INDEX_TYPE newCapacity ) LVARRAY_RESTRICT_THIS
+  void reserveCapacityOfSet( INDEX_TYPE const i, INDEX_TYPE newCapacity )
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
     if( newCapacity > capacityOfSet( i ) ) setCapacityOfSet( i, newCapacity );
@@ -475,7 +520,7 @@ public:
      * @return a pointer to the sets values.
      */
     inline
-    T * incrementSize( T * const curPtr, INDEX_TYPE const nToAdd ) const LVARRAY_RESTRICT_THIS
+    T * incrementSize( T * const curPtr, INDEX_TYPE const nToAdd ) const
     {
       LVARRAY_UNUSED_VARIABLE( curPtr );
       INDEX_TYPE const newNNZ = m_aos.sizeOfSet( m_i ) + nToAdd;

--- a/src/ArrayOfSetsView.hpp
+++ b/src/ArrayOfSetsView.hpp
@@ -61,6 +61,12 @@ public:
   ///@{
 
   /**
+   * @brief A constructor to create an uninitialized ArrayOfSetsView.
+   * @note An uninitialized ArrayOfSetsView should not be used until it is assigned to.
+   */
+  ArrayOfSetsView() = default;
+
+  /**
    * @brief Default copy constructor. Performs a shallow copy and calls the
    *   chai::ManagedArray copy constructor.
    */
@@ -114,7 +120,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   ArrayOfSetsView< T, INDEX_TYPE const, BUFFER_TYPE >
-  toView() const LVARRAY_RESTRICT_THIS
+  toView() const
   {
     return ArrayOfSetsView< T, INDEX_TYPE const, BUFFER_TYPE >( size(),
                                                                 this->m_offsets,
@@ -127,7 +133,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   ArrayOfSetsView< T const, INDEX_TYPE const, BUFFER_TYPE >
-  toViewConst() const LVARRAY_RESTRICT_THIS
+  toViewConst() const
   {
     return ArrayOfSetsView< T const, INDEX_TYPE const, BUFFER_TYPE >( size(),
                                                                       this->m_offsets,
@@ -140,7 +146,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   ArrayOfArraysView< T const, INDEX_TYPE const, true, BUFFER_TYPE >
-  toArrayOfArraysView() const LVARRAY_RESTRICT_THIS
+  toArrayOfArraysView() const
   {
     return ArrayOfArraysView< T const, INDEX_TYPE const, true, BUFFER_TYPE >( size(),
                                                                               this->m_offsets,
@@ -162,7 +168,7 @@ public:
    * @param i The set to get the size of.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  INDEX_TYPE_NC sizeOfSet( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC sizeOfSet( INDEX_TYPE const i ) const
   { return ParentClass::sizeOfArray( i ); }
 
   using ParentClass::capacity;
@@ -172,7 +178,7 @@ public:
    * @param i The set to get the capacity of.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  INDEX_TYPE_NC capacityOfSet( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC capacityOfSet( INDEX_TYPE const i ) const
   { return ParentClass::capacityOfArray( i ); }
 
   using ParentClass::valueCapacity;
@@ -183,7 +189,7 @@ public:
    * @param value the value to search for.
    */
   LVARRAY_HOST_DEVICE inline
-  bool contains( INDEX_TYPE const i, T const & value ) const LVARRAY_RESTRICT_THIS
+  bool contains( INDEX_TYPE const i, T const & value ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
 
@@ -198,7 +204,7 @@ public:
    *   size and that each set is sorted unique.
    * @note The is intended for debugging.
    */
-  void consistencyCheck() const LVARRAY_RESTRICT_THIS
+  void consistencyCheck() const
   {
     INDEX_TYPE const numSets = size();
     for( INDEX_TYPE_NC i = 0; i < numSets; ++i )
@@ -224,7 +230,7 @@ public:
    * @param i The set to access.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  ArraySlice< T const, 1, 0, INDEX_TYPE_NC > operator[]( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
+  ArraySlice< T const, 1, 0, INDEX_TYPE_NC > operator[]( INDEX_TYPE const i ) const
   { return ParentClass::operator[]( i ); }
 
   /**
@@ -233,7 +239,7 @@ public:
    * @param j The index within the set to access.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  T const & operator()( INDEX_TYPE const i, INDEX_TYPE const j ) const LVARRAY_RESTRICT_THIS
+  T const & operator()( INDEX_TYPE const i, INDEX_TYPE const j ) const
   { return ParentClass::operator()( i, j ); }
 
   ///@}
@@ -252,7 +258,7 @@ public:
    *   up to the user to ensure that the given set has enough space for the new entries.
    */
   LVARRAY_HOST_DEVICE inline
-  bool insertIntoSet( INDEX_TYPE const i, T const & value ) const LVARRAY_RESTRICT_THIS
+  bool insertIntoSet( INDEX_TYPE const i, T const & value ) const
   { return insertIntoSetImpl( i, value, CallBacks( *this, i ) ); }
 
   /**
@@ -268,7 +274,7 @@ public:
    */
   template< typename ITER >
   LVARRAY_HOST_DEVICE inline
-  INDEX_TYPE_NC insertIntoSet( INDEX_TYPE const i, ITER const first, ITER const last ) const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC insertIntoSet( INDEX_TYPE const i, ITER const first, ITER const last ) const
   { return insertIntoSetImpl( i, first, last, CallBacks( *this, i ) ); }
 
   /**
@@ -278,7 +284,7 @@ public:
    * @return True iff the value was removed (the set previously contained the value).
    */
   LVARRAY_HOST_DEVICE inline
-  bool removeFromSet( INDEX_TYPE const i, T const & value ) const LVARRAY_RESTRICT_THIS
+  bool removeFromSet( INDEX_TYPE const i, T const & value ) const
   { return removeFromSetImpl( i, value, CallBacks( *this, i ) ); }
 
   /**
@@ -292,7 +298,7 @@ public:
    */
   template< typename ITER >
   LVARRAY_HOST_DEVICE inline
-  INDEX_TYPE_NC removeFromSet( INDEX_TYPE const i, ITER const first, ITER const last ) const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC removeFromSet( INDEX_TYPE const i, ITER const first, ITER const last ) const
   { return removeFromSetImpl( i, first, last, CallBacks( *this, i ) ); }
 
   ///@}
@@ -319,11 +325,12 @@ public:
 protected:
 
   /**
-   * @brief Default constructor.
-   * @note Protected since every ArrayOfSetsView should either be the base of a ArrayOfSets
-   *   or copied from another ArrayOfSetsView.
+   * @brief Protected constructor to be used by parent classes.
+   * @note The unused boolean parameter is to distinguish this from the default constructor.
    */
-  ArrayOfSetsView() = default;
+  ArrayOfSetsView( bool ):
+    ParentClass( true )
+  {}
 
   /**
    * @return Return an ArraySlice1d to the values of the given array.
@@ -331,7 +338,7 @@ protected:
    * @note Protected because it returns a non-const pointer.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  ArraySlice< T, 1, 0, INDEX_TYPE_NC > getSetValues( INDEX_TYPE const i ) const LVARRAY_RESTRICT_THIS
+  ArraySlice< T, 1, 0, INDEX_TYPE_NC > getSetValues( INDEX_TYPE const i ) const
   { return ParentClass::operator[]( i ); }
 
   /**
@@ -349,7 +356,7 @@ protected:
    */
   template< typename CALLBACKS >
   LVARRAY_HOST_DEVICE inline
-  bool insertIntoSetImpl( INDEX_TYPE const i, T const & value, CALLBACKS && cbacks ) const LVARRAY_RESTRICT_THIS
+  bool insertIntoSetImpl( INDEX_TYPE const i, T const & value, CALLBACKS && cbacks ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
 
@@ -377,7 +384,7 @@ protected:
   INDEX_TYPE_NC insertIntoSetImpl( INDEX_TYPE const i,
                                    ITER const first,
                                    ITER const last,
-                                   CALLBACKS && cbacks ) const LVARRAY_RESTRICT_THIS
+                                   CALLBACKS && cbacks ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
 
@@ -403,7 +410,7 @@ protected:
    */
   template< typename CALLBACKS >
   LVARRAY_HOST_DEVICE inline
-  bool removeFromSetImpl( INDEX_TYPE const i, T const & value, CALLBACKS && cbacks ) const LVARRAY_RESTRICT_THIS
+  bool removeFromSetImpl( INDEX_TYPE const i, T const & value, CALLBACKS && cbacks ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
 
@@ -431,7 +438,7 @@ protected:
   INDEX_TYPE_NC removeFromSetImpl( INDEX_TYPE const i,
                                    ITER const first,
                                    ITER const last,
-                                   CALLBACKS && cbacks ) const LVARRAY_RESTRICT_THIS
+                                   CALLBACKS && cbacks ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( i );
 
@@ -479,7 +486,7 @@ public:
      * @return a pointer to the sets values.
      */
     LVARRAY_HOST_DEVICE inline
-    T * incrementSize( T * const curPtr, INDEX_TYPE const nToAdd ) const LVARRAY_RESTRICT_THIS
+    T * incrementSize( T * const curPtr, INDEX_TYPE const nToAdd ) const
     {
       LVARRAY_UNUSED_VARIABLE( curPtr );
 #ifdef LVARRAY_BOUNDS_CHECK

--- a/src/ArraySlice.hpp
+++ b/src/ArraySlice.hpp
@@ -144,7 +144,7 @@ public:
   template< typename U=T >
   LVARRAY_HOST_DEVICE inline constexpr
   ArraySlice< T const, NDIM, USD, INDEX_TYPE >
-  toSliceConst() const LVARRAY_RESTRICT_THIS noexcept
+  toSliceConst() const noexcept
   { return ArraySlice< T const, NDIM, USD, INDEX_TYPE >( m_data, m_dims, m_strides ); }
 
   /**
@@ -154,7 +154,7 @@ public:
   LVARRAY_HOST_DEVICE inline constexpr
   operator std::enable_if_t< !std::is_const< U >::value,
                              ArraySlice< T const, NDIM, USD, INDEX_TYPE > >
-    () const LVARRAY_RESTRICT_THIS noexcept
+    () const noexcept
   { return toSliceConst(); }
 
   ///@}
@@ -264,7 +264,7 @@ public:
   template< int _NDIM=NDIM, int _USD=USD >
   LVARRAY_HOST_DEVICE constexpr inline
   operator std::enable_if_t< _NDIM == 1 && _USD == 0, T * const LVARRAY_RESTRICT >
-    () const noexcept LVARRAY_RESTRICT_THIS
+    () const noexcept
   { return m_data; }
 
   /**
@@ -275,7 +275,7 @@ public:
   template< int U=NDIM >
   LVARRAY_HOST_DEVICE inline CONSTEXPR_WITHOUT_BOUNDS_CHECK
   std::enable_if_t< (U > 1), ArraySlice< T, NDIM - 1, USD - 1, INDEX_TYPE > >
-  operator[]( INDEX_TYPE const index ) const noexcept LVARRAY_RESTRICT_THIS
+  operator[]( INDEX_TYPE const index ) const noexcept
   {
     ARRAY_SLICE_CHECK_BOUNDS( index );
     return ArraySlice< T, NDIM-1, USD-1, INDEX_TYPE >( m_data + indexing::ConditionalMultiply< USD == 0 >::multiply( index, m_strides[ 0 ] ),
@@ -291,7 +291,7 @@ public:
   template< int U=NDIM >
   LVARRAY_HOST_DEVICE inline CONSTEXPR_WITHOUT_BOUNDS_CHECK
   std::enable_if_t< U == 1, T & >
-  operator[]( INDEX_TYPE const index ) const noexcept LVARRAY_RESTRICT_THIS
+  operator[]( INDEX_TYPE const index ) const noexcept
   {
     ARRAY_SLICE_CHECK_BOUNDS( index );
     return m_data[ indexing::ConditionalMultiply< USD == 0 >::multiply( index, m_strides[ 0 ] ) ];

--- a/src/ArrayView.hpp
+++ b/src/ArrayView.hpp
@@ -229,17 +229,17 @@ public:
   ///@{
 
   /**
-   * @return Return *this after converting any nested arrays to const views.
+   * @return Return a new ArrayView.
    */
   inline LVARRAY_HOST_DEVICE constexpr
-  ArrayView toView() const
+  ArrayView toView() const &
   { return ArrayView( m_dims, m_strides, m_singleParameterResizeIndex, m_dataBuffer ); }
 
   /**
-   * @return Return *this after converting any nested arrays to const views to const values.
+   * @return Return a new ArrayView where @c T is @c const.
    */
   inline LVARRAY_HOST_DEVICE constexpr
-  ArrayView< T const, NDIM, USD, INDEX_TYPE, BUFFER_TYPE > toViewConst() const
+  ArrayView< T const, NDIM, USD, INDEX_TYPE, BUFFER_TYPE > toViewConst() const &
   {
     return ArrayView< T const, NDIM, USD, INDEX_TYPE, BUFFER_TYPE >( m_dims,
                                                                      m_strides,
@@ -251,14 +251,14 @@ public:
    * @brief @return Return *this after converting any nested arrays to const views.
    */
   inline LVARRAY_HOST_DEVICE constexpr
-  NestedViewType toNestedView() const
+  NestedViewType toNestedView() const &
   { return reinterpret_cast< NestedViewType const & >( *this ); }
 
   /**
    * @brief @return Return *this after converting any nested arrays to const views to const values.
    */
   inline LVARRAY_HOST_DEVICE constexpr
-  NestedViewTypeConst toNestedViewConst() const
+  NestedViewTypeConst toNestedViewConst() const &
   { return reinterpret_cast< NestedViewTypeConst const & >( *this ); }
 
   /**
@@ -272,22 +272,21 @@ public:
   /**
    * @brief Overload for rvalues that raises a compilation error when used.
    * @return A null ArraySlice.
-   * @brief @c toSlice cannot be called on a rvalue since the @c ArraySlice would
-   *   contain pointers to the object that is about to be destroyed. This overload
-   *   prevents that from happening.
+   * @note This cannot be called on a rvalue since the @c ArraySlice would
+   *   contain pointers to the dims and strides of the current @c ArrayView that is
+   *   about to be destroyed. This overload prevents that from happening.
    */
   inline LVARRAY_HOST_DEVICE constexpr
   ArraySlice< T, NDIM, USD, INDEX_TYPE >
   toSlice() const && noexcept
   {
-    static_assert( NDIM < 0, "Cannot call toSlice on a rvalue." );
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toSlice on a rvalue." );
     return ArraySlice< T, NDIM, USD, INDEX_TYPE >( nullptr, nullptr, nullptr );
   }
 
   /**
    * @return Return an immutable ArraySlice representing this ArrayView.
    */
-  template< typename _T=T >
   inline LVARRAY_HOST_DEVICE constexpr
   ArraySlice< T const, NDIM, USD, INDEX_TYPE >
   toSliceConst() const & noexcept
@@ -296,27 +295,44 @@ public:
   /**
    * @brief Overload for rvalues that raises a compilation error when used.
    * @return A null ArraySlice.
-   * @brief @c toSliceConst cannot be called on a rvalue since the @c ArraySlice would
-   *   contain pointers to the object that is about to be destroyed. This overload
-   *   prevents that from happening.
+   * @brief This cannot be called on a rvalue since the @c ArraySlice would
+   *   contain pointers to the dims and strides of the current @c ArrayView that is
+   *   about to be destroyed. This overload prevents that from happening.
    */
-  template< typename _T=T >
   inline LVARRAY_HOST_DEVICE constexpr
   ArraySlice< T const, NDIM, USD, INDEX_TYPE >
   toSliceConst() const && noexcept
   {
-    static_assert( NDIM < 0, "Cannot call toSliceConst on a rvalue." );
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toSliceConst on a rvalue." );
     return ArraySlice< T const, NDIM, USD, INDEX_TYPE >( nullptr, nullptr, nullptr );
   }
 
   /**
-   * @return Return *this interpret as ArrayView<T const> const &.
+   * @brief A user defined conversion operator (UDC) to an ArrayView< T const, ... >.
+   * @return A new ArrayView where @c T is @c const.
    */
   template< typename _T=T >
   inline LVARRAY_HOST_DEVICE constexpr
   operator std::enable_if_t< !std::is_const< _T >::value,
-                             ArrayView< T const, NDIM, USD, INDEX_TYPE, BUFFER_TYPE > >() const noexcept
+                             ArrayView< T const, NDIM, USD, INDEX_TYPE, BUFFER_TYPE > >() const & noexcept
   { return toViewConst(); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArrayView.
+   * @brief This is valid when this is an @c ArrayView but invalid when this is an @c Array.
+   *   I have been unable to allow the @c ArrayView conversion while not allowing the @c Array.
+   *   Therefore the @c ArrayView conversion is not allowed, instead simply call @c toViewConst.
+   */
+  template< typename _T=T >
+  inline LVARRAY_HOST_DEVICE constexpr
+  operator std::enable_if_t< !std::is_const< _T >::value,
+                             ArrayView< T const, NDIM, USD, INDEX_TYPE, BUFFER_TYPE > >() const && noexcept
+  {
+    static_assert( !typeManipulation::always_true< T >,
+                   "Cannot call toViewConst on a rvalue. If called from ArrayView please use toViewConst()." );
+    return toViewConst();
+  }
 
   /**
    * @return Return an ArraySlice representing this ArrayView.
@@ -329,13 +345,13 @@ public:
    * @brief Overload for rvalues that raises a compilation error when used.
    * @return A null ArraySlice.
    * @brief This conversion cannot be called on a rvalue since the @c ArraySlice would
-   *   contain pointers to the object that is about to be destroyed. This overload
-   *   prevents that from happening.
+   *   contain pointers to the dims and strides of the current @c ArrayView that is
+   *   about to be destroyed. This overload prevents that from happening.
    */
   inline LVARRAY_HOST_DEVICE constexpr
   operator ArraySlice< T, NDIM, USD, INDEX_TYPE >() const && noexcept
   {
-    static_assert( NDIM < 0, "Cannot use to conversion to an ArraySlice< T, ... > on a rvalue." );
+    static_assert( !typeManipulation::always_true< T >, "Cannot use conversion to an ArraySlice< T, ... > on a rvalue." );
     return ArraySlice< T, NDIM, USD, INDEX_TYPE >( nullptr, nullptr, nullptr );
   }
 
@@ -352,15 +368,15 @@ public:
    * @brief Overload for rvalues that raises a compilation error when used.
    * @return A null ArraySlice.
    * @brief This conversion cannot be called on a rvalue since the @c ArraySlice would
-   *   contain pointers to the object that is about to be destroyed. This overload
-   *   prevents that from happening.
+   *   contain pointers to the dims and strides of the current @c ArrayView that is
+   *   about to be destroyed. This overload prevents that from happening.
    */
   template< typename _T=T >
   inline LVARRAY_HOST_DEVICE constexpr
   operator std::enable_if_t< !std::is_const< _T >::value,
                              ArraySlice< T const, NDIM, USD, INDEX_TYPE > const >() const && noexcept
   {
-    static_assert( NDIM < 0, "Cannot use to conversion to an ArraySlice< T const, ... > on a rvalue." );
+    static_assert( !typeManipulation::always_true< T >, "Cannot use conversion to an ArraySlice< T const, ... > on a rvalue." );
     return ArraySlice< T const, NDIM, USD, INDEX_TYPE >( nullptr, nullptr, nullptr );
   }
 
@@ -470,7 +486,7 @@ public:
   template< int _NDIM=NDIM >
   LVARRAY_HOST_DEVICE inline CONSTEXPR_WITHOUT_BOUNDS_CHECK
   std::enable_if_t< (_NDIM > 1), ArraySlice< T, NDIM - 1, USD - 1, INDEX_TYPE > >
-  operator[]( INDEX_TYPE const index ) const & noexcept LVARRAY_RESTRICT_THIS
+  operator[]( INDEX_TYPE const index ) const & noexcept
   {
     ARRAY_SLICE_CHECK_BOUNDS( index );
     return ArraySlice< T, NDIM-1, USD-1, INDEX_TYPE >( data() + indexing::ConditionalMultiply< USD == 0 >::multiply( index, m_strides[ 0 ] ),
@@ -489,10 +505,10 @@ public:
   template< int _NDIM=NDIM >
   LVARRAY_HOST_DEVICE inline CONSTEXPR_WITHOUT_BOUNDS_CHECK
   std::enable_if_t< (_NDIM > 1), ArraySlice< T, NDIM - 1, USD - 1, INDEX_TYPE > >
-  operator[]( INDEX_TYPE const index ) const && noexcept LVARRAY_RESTRICT_THIS
+  operator[]( INDEX_TYPE const index ) const && noexcept
   {
     LVARRAY_UNUSED_VARIABLE( index );
-    static_assert( NDIM < 0, "Cannot call operator[] on an rvalue." );
+    static_assert( !typeManipulation::always_true< T >, "Cannot call multidimensional operator[] on an rvalue." );
     return ArraySlice< T, NDIM-1, USD-1, INDEX_TYPE >( nullptr, nullptr, nullptr );
   }
 
@@ -504,7 +520,7 @@ public:
   template< int _NDIM=NDIM >
   LVARRAY_HOST_DEVICE inline CONSTEXPR_WITHOUT_BOUNDS_CHECK
   std::enable_if_t< _NDIM == 1, T & >
-  operator[]( INDEX_TYPE const index ) const & noexcept LVARRAY_RESTRICT_THIS
+  operator[]( INDEX_TYPE const index ) const & noexcept
   {
     ARRAY_SLICE_CHECK_BOUNDS( index );
     return data()[ indexing::ConditionalMultiply< USD == 0 >::multiply( index, m_strides[ 0 ] ) ];

--- a/src/CRSMatrix.hpp
+++ b/src/CRSMatrix.hpp
@@ -58,7 +58,7 @@ public:
   CRSMatrix( INDEX_TYPE const nrows=0,
              INDEX_TYPE const ncols=0,
              INDEX_TYPE const initialRowCapacity=0 ):
-    ParentClass()
+    ParentClass( true )
   {
     resize( nrows, ncols, initialRowCapacity );
     setName( "" );
@@ -70,7 +70,7 @@ public:
    */
   inline
   CRSMatrix( CRSMatrix const & src ):
-    ParentClass()
+    ParentClass( true )
   { *this = src; }
 
   /**
@@ -98,7 +98,7 @@ public:
    * @return *this.
    */
   inline
-  CRSMatrix & operator=( CRSMatrix const & src ) LVARRAY_RESTRICT_THIS
+  CRSMatrix & operator=( CRSMatrix const & src )
   {
     this->m_numCols = src.m_numCols;
     ParentClass::setEqualTo( src.m_numArrays,
@@ -199,8 +199,23 @@ public:
    */
   constexpr inline
   CRSMatrixView< T, COL_TYPE, INDEX_TYPE const, BUFFER_TYPE >
-  toView() const LVARRAY_RESTRICT_THIS
+  toView() const &
   { return ParentClass::toView(); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null CRSMatrixView.
+   * @note This cannot be called on a rvalue since the @c CRSMatrixView would
+   *   contain the buffers of the current @c CRSMatrix that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  constexpr inline
+  CRSMatrixView< T, COL_TYPE, INDEX_TYPE const, BUFFER_TYPE >
+  toView() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toView on a rvalue." );
+    return ParentClass::toView();
+  }
 
   /**
    * @copydoc ParentClass::toViewConstSizes
@@ -210,8 +225,23 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   CRSMatrixView< T, COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >
-  toViewConstSizes() const LVARRAY_RESTRICT_THIS
+  toViewConstSizes() const &
   { return ParentClass::toViewConstSizes(); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null CRSMatrixView.
+   * @note This cannot be called on a rvalue since the @c CRSMatrixView would
+   *   contain the buffers of the current @c CRSMatrix that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  LVARRAY_HOST_DEVICE constexpr inline
+  CRSMatrixView< T, COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >
+  toViewConstSizes() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toViewConstSizes on a rvalue." );
+    return ParentClass::toViewConstSizes();
+  }
 
   /**
    * @copydoc ParentClass::toViewConst
@@ -221,10 +251,40 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   CRSMatrixView< T const, COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >
-  toViewConst() const LVARRAY_RESTRICT_THIS
+  toViewConst() const &
   { return ParentClass::toViewConst(); }
 
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null CRSMatrixView.
+   * @note This cannot be called on a rvalue since the @c CRSMatrixView would
+   *   contain the buffers of the current @c CRSMatrix that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  LVARRAY_HOST_DEVICE constexpr inline
+  CRSMatrixView< T const, COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >
+  toViewConst() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toViewConst on a rvalue." );
+    return ParentClass::toViewConst();
+  }
+
   using ParentClass::toSparsityPatternView;
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null CRSMatrixView.
+   * @note This cannot be called on a rvalue since the @c SparsityPatternView would
+   *   contain the buffers of the current @c CRSMatrix that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  LVARRAY_HOST_DEVICE constexpr inline
+  SparsityPatternView< COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >
+  toSparsityPatternView() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toSparsityPatternView on a rvalue." );
+    return ParentClass::toSparsityPatternView();
+  }
 
   ///@}
 
@@ -262,7 +322,7 @@ public:
    * @param nnz the number of no zero entries to reserve space for.
    */
   inline
-  void reserveNonZeros( INDEX_TYPE const nnz ) LVARRAY_RESTRICT_THIS
+  void reserveNonZeros( INDEX_TYPE const nnz )
   { ParentClass::reserveValues( nnz, this->m_entries ); }
 
   /**
@@ -271,7 +331,7 @@ public:
    * @param nnz the number of no zero entries to reserve space for.
    */
   inline
-  void reserveNonZeros( INDEX_TYPE const row, INDEX_TYPE const nnz ) LVARRAY_RESTRICT_THIS
+  void reserveNonZeros( INDEX_TYPE const row, INDEX_TYPE const nnz )
   {
     if( nonZeroCapacity( row ) >= nnz ) return;
     setRowCapacity( row, nnz );
@@ -304,7 +364,7 @@ public:
    *   or where a specific column is greater than the number of columns in the matrix.
    *   If you will be constructing the matrix from scratch it is reccomended to clear it first.
    */
-  void resize( INDEX_TYPE const nRows, INDEX_TYPE const nCols, INDEX_TYPE const initialRowCapacity ) LVARRAY_RESTRICT_THIS
+  void resize( INDEX_TYPE const nRows, INDEX_TYPE const nCols, INDEX_TYPE const initialRowCapacity )
   { ParentClass::resize( nRows, nCols, initialRowCapacity, this->m_entries ); }
 
   /**
@@ -313,7 +373,7 @@ public:
    * @note This method doesn't free any memory.
    */
   inline
-  void compress() LVARRAY_RESTRICT_THIS
+  void compress()
   { ParentClass::compress( this->m_entries ); }
 
   ///@}
@@ -331,7 +391,7 @@ public:
    * @return True iff the entry was inserted (the entry was zero before).
    */
   inline
-  bool insertNonZero( INDEX_TYPE const row, COL_TYPE const col, T const & entry ) LVARRAY_RESTRICT_THIS
+  bool insertNonZero( INDEX_TYPE const row, COL_TYPE const col, T const & entry )
   { return ParentClass::insertIntoSetImpl( row, col, CallBacks( *this, row, &entry ) ); }
 
   /**
@@ -348,7 +408,7 @@ public:
   INDEX_TYPE insertNonZeros( INDEX_TYPE const row,
                              COL_TYPE const * const cols,
                              T const * const entriesToInsert,
-                             INDEX_TYPE const ncols ) LVARRAY_RESTRICT_THIS
+                             INDEX_TYPE const ncols )
   { return ParentClass::insertIntoSetImpl( row, cols, cols + ncols, CallBacks( *this, row, entriesToInsert ) ); }
 
   using ParentClass::removeNonZero;

--- a/src/CRSMatrixView.hpp
+++ b/src/CRSMatrixView.hpp
@@ -97,6 +97,12 @@ public:
   ///@{
 
   /**
+   * @brief A constructor to create an uninitialized CRSMatrixView.
+   * @note An uninitialized CRSMatrixView should not be used until it is assigned to.
+   */
+  CRSMatrixView() = default;
+
+  /**
    * @brief Default copy constructor.
    */
   CRSMatrixView( CRSMatrixView const & ) = default;
@@ -151,7 +157,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   CRSMatrixView< T, COL_TYPE, INDEX_TYPE const, BUFFER_TYPE >
-  toView() const LVARRAY_RESTRICT_THIS
+  toView() const
   {
     return CRSMatrixView< T, COL_TYPE, INDEX_TYPE const, BUFFER_TYPE >( numRows(),
                                                                         numColumns(),
@@ -166,7 +172,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   CRSMatrixView< T, COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >
-  toViewConstSizes() const LVARRAY_RESTRICT_THIS
+  toViewConstSizes() const
   {
     return CRSMatrixView< T, COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >( numRows(),
                                                                               numColumns(),
@@ -181,7 +187,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   CRSMatrixView< T const, COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >
-  toViewConst() const LVARRAY_RESTRICT_THIS
+  toViewConst() const
   {
     return CRSMatrixView< T const, COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >( numRows(),
                                                                                     numColumns(),
@@ -196,7 +202,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   SparsityPatternView< COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >
-  toSparsityPatternView() const
+  toSparsityPatternView() const &
   {
     return SparsityPatternView< COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >( numRows(),
                                                                                  numColumns(),
@@ -230,7 +236,7 @@ public:
    * @param row The row to access.
    */
   LVARRAY_HOST_DEVICE inline
-  ArraySlice< T, 1, 0, INDEX_TYPE_NC > getEntries( INDEX_TYPE const row ) const LVARRAY_RESTRICT_THIS
+  ArraySlice< T, 1, 0, INDEX_TYPE_NC > getEntries( INDEX_TYPE const row ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( row );
     return ArraySlice< T, 1, 0, INDEX_TYPE_NC >( m_entries.data() + this->m_offsets[ row ],
@@ -258,7 +264,7 @@ public:
    *   up to the user to ensure that the given row has enough space for the new entry.
    */
   LVARRAY_HOST_DEVICE inline
-  bool insertNonZero( INDEX_TYPE const row, COL_TYPE const col, T const & entry ) const LVARRAY_RESTRICT_THIS
+  bool insertNonZero( INDEX_TYPE const row, COL_TYPE const col, T const & entry ) const
   { return ParentClass::insertIntoSetImpl( row, col, CallBacks( *this, row, &entry ) ); }
 
   /**
@@ -276,7 +282,7 @@ public:
   INDEX_TYPE_NC insertNonZeros( INDEX_TYPE const row,
                                 COL_TYPE const * const LVARRAY_RESTRICT cols,
                                 T const * const LVARRAY_RESTRICT entriesToInsert,
-                                INDEX_TYPE const ncols ) const LVARRAY_RESTRICT_THIS
+                                INDEX_TYPE const ncols ) const
   { return ParentClass::insertIntoSetImpl( row, cols, cols + ncols, CallBacks( *this, row, entriesToInsert ) ); }
 
   /**
@@ -286,7 +292,7 @@ public:
    * @return True iff the entry was removed (the entry was non-zero before).
    */
   LVARRAY_HOST_DEVICE inline
-  bool removeNonZero( INDEX_TYPE const row, COL_TYPE const col ) const LVARRAY_RESTRICT_THIS
+  bool removeNonZero( INDEX_TYPE const row, COL_TYPE const col ) const
   { return ParentClass::removeFromSetImpl( row, col, CallBacks( *this, row, nullptr )); }
 
   /**
@@ -301,7 +307,7 @@ public:
   LVARRAY_HOST_DEVICE inline
   INDEX_TYPE_NC removeNonZeros( INDEX_TYPE const row,
                                 COL_TYPE const * const LVARRAY_RESTRICT cols,
-                                INDEX_TYPE const ncols ) const LVARRAY_RESTRICT_THIS
+                                INDEX_TYPE const ncols ) const
   {
     T * const entries = getEntries( row );
     INDEX_TYPE const rowNNZ = numNonZeros( row );
@@ -505,11 +511,11 @@ public:
 protected:
 
   /**
-   * @brief Default constructor. Made protected since every CRSMatrixView should
-   *        either be the base of a CRSMatrix or copied from another CRSMatrixView.
+   * @brief Protected constructor to be used by the CRSMatrix class.
+   * @note The unused boolean parameter is to distinguish this from the default constructor.
    */
-  CRSMatrixView():
-    ParentClass(),
+  CRSMatrixView( bool ):
+    ParentClass( true ),
     m_entries( true )
   {}
 

--- a/src/Macros.hpp
+++ b/src/Macros.hpp
@@ -405,18 +405,15 @@
 #if defined(__clang__)
 #define LVARRAY_RESTRICT __restrict__
 #define LVARRAY_RESTRICT_REF __restrict__
-#define LVARRAY_RESTRICT_THIS
 #define LVARRAY_INTEL_CONSTEXPR constexpr
 #elif defined(__GNUC__)
   #if defined(__INTEL_COMPILER)
 #define LVARRAY_RESTRICT __restrict__
 #define LVARRAY_RESTRICT_REF __restrict__
-#define LVARRAY_RESTRICT_THIS
 #define LVARRAY_INTEL_CONSTEXPR
   #else
 #define LVARRAY_RESTRICT __restrict__
 #define LVARRAY_RESTRICT_REF __restrict__
-#define LVARRAY_RESTRICT_THIS
 #define LVARRAY_INTEL_CONSTEXPR constexpr
   #endif
 #endif

--- a/src/SortedArray.hpp
+++ b/src/SortedArray.hpp
@@ -89,7 +89,7 @@ public:
    * @brief Destructor, frees the values array.
    */
   inline
-  ~SortedArray() LVARRAY_RESTRICT_THIS
+  ~SortedArray()
   { bufferManipulation::free( this->m_values, size() ); }
 
   /**
@@ -98,7 +98,7 @@ public:
    * @return *this.
    */
   inline
-  SortedArray & operator=( SortedArray const & src ) LVARRAY_RESTRICT_THIS
+  SortedArray & operator=( SortedArray const & src )
   {
     bufferManipulation::copyInto( this->m_values, size(), src.m_values, src.size() );
     this->m_size = src.size();
@@ -127,8 +127,22 @@ public:
    *   IS_VALID_EXPRESSION and this fails with NVCC.
    */
   LVARRAY_HOST_DEVICE inline
-  SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE > toView() const LVARRAY_RESTRICT_THIS
+  SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE > toView() const &
   { return ParentClass::toView(); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null SortedArrayView.
+   * @note This cannot be called on a rvalue since the @c SortedArrayView would
+   *   contain the buffer of the current @c SortedArray that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  LVARRAY_HOST_DEVICE inline
+  SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE > toView() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toView on a rvalue." );
+    return ParentClass::toView();
+  }
 
   /**
    * @copydoc ParentClass::toViewConst()
@@ -137,8 +151,22 @@ public:
    *   IS_VALID_EXPRESSION and this fails with NVCC.
    */
   LVARRAY_HOST_DEVICE inline
-  SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE > toViewConst() const LVARRAY_RESTRICT_THIS
+  SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE > toViewConst() const &
   { return ParentClass::toViewConst(); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null SortedArrayView.
+   * @note This cannot be called on a rvalue since the @c SortedArrayView would
+   *   contain the buffer of the current @c SortedArray that is about to be destroyed.
+   *   This overload prevents that from happening.
+   */
+  LVARRAY_HOST_DEVICE inline
+  SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE > toViewConst() const &&
+  {
+    static_assert( !typeManipulation::always_true< T >, "Cannot call toViewConst on a rvalue." );
+    return ParentClass::toViewConst();
+  }
 
   ///@}
 
@@ -197,7 +225,7 @@ public:
    * @return True iff the value was actually inserted.
    */
   inline
-  bool insert( T const & value ) LVARRAY_RESTRICT_THIS
+  bool insert( T const & value )
   {
     bool const success = sortedArrayManipulation::insert( this->m_values.data(),
                                                           size(),
@@ -216,7 +244,7 @@ public:
    * @note [ @p first, @p last ) must be sorted and unique.
    */
   template< typename ITER >
-  INDEX_TYPE insert( ITER const first, ITER const last ) LVARRAY_RESTRICT_THIS
+  INDEX_TYPE insert( ITER const first, ITER const last )
   {
     INDEX_TYPE const nInserted = sortedArrayManipulation::insert( this->m_values.data(),
                                                                   size(),
@@ -233,7 +261,7 @@ public:
    * @return True iff the value was actually removed.
    */
   inline
-  bool remove( T const & value ) LVARRAY_RESTRICT_THIS
+  bool remove( T const & value )
   {
     bool const success = sortedArrayManipulation::remove( this->m_values.data(),
                                                           size(),
@@ -252,7 +280,7 @@ public:
    * @note [ @p first, @p last ) must be sorted and unique.
    */
   template< typename ITER >
-  INDEX_TYPE remove( ITER const first, ITER const last ) LVARRAY_RESTRICT_THIS
+  INDEX_TYPE remove( ITER const first, ITER const last )
   {
     INDEX_TYPE const nRemoved = sortedArrayManipulation::remove( this->m_values.data(),
                                                                  size(),
@@ -274,7 +302,7 @@ public:
    * @brief Remove all the values from the array.
    */
   inline
-  void clear() LVARRAY_RESTRICT_THIS
+  void clear()
   {
     bufferManipulation::resize( this->m_values, size(), 0 );
     this->m_size = 0;
@@ -285,7 +313,7 @@ public:
    * @param nVals the number of values to reserve space for.
    */
   inline
-  void reserve( INDEX_TYPE const nVals ) LVARRAY_RESTRICT_THIS
+  void reserve( INDEX_TYPE const nVals )
   { bufferManipulation::reserve( this->m_values, size(), nVals ); }
 
   ///@}
@@ -302,7 +330,7 @@ public:
    *   IS_VALID_EXPRESSION and this fails with NVCC.
    */
   inline
-  void move( MemorySpace const space, bool const touch=true ) const LVARRAY_RESTRICT_THIS
+  void move( MemorySpace const space, bool const touch=true ) const
   { ParentClass::move( space, touch ); }
 
   ///@}
@@ -344,7 +372,7 @@ public:
      */
     inline
     T * incrementSize( T * const curPtr,
-                       INDEX_TYPE const nToAdd ) const LVARRAY_RESTRICT_THIS
+                       INDEX_TYPE const nToAdd ) const
     {
       LVARRAY_UNUSED_VARIABLE( curPtr );
       bufferManipulation::dynamicReserve( m_buffer, m_size, m_size + nToAdd );

--- a/src/SortedArray.hpp
+++ b/src/SortedArray.hpp
@@ -168,6 +168,8 @@ public:
     return ParentClass::toViewConst();
   }
 
+  using ParentClass::toSlice;
+
   ///@}
 
   /**
@@ -198,6 +200,7 @@ public:
   ///@{
 
   using ParentClass::operator[];
+  using ParentClass::operator();
 
   /**
    * @copydoc SortedArrayView::data

--- a/src/SortedArrayView.hpp
+++ b/src/SortedArrayView.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 // Source includes
+#include "ArraySlice.hpp"
 #include "bufferManipulation.hpp"
 #include "sortedArrayManipulation.hpp"
 
@@ -129,7 +130,7 @@ public:
   ///@}
 
   /**
-   * @name SortedArrayView creation methods
+   * @name SortedArrayView and ArraySlice creation methods
    */
   ///@{
 
@@ -148,6 +149,27 @@ public:
   SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE >
   toViewConst() const
   { return toView(); }
+
+  /**
+   * @return Return an ArraySlice representing this SortedArrayView.
+   */
+  LVARRAY_HOST_DEVICE constexpr inline
+  ArraySlice< T const, 1, 0, INDEX_TYPE > toSlice() const &
+  { return ArraySlice< T const, 1, 0, INDEX_TYPE >( data(), &m_size, nullptr ); }
+
+  /**
+   * @brief Overload for rvalues that raises a compilation error when used.
+   * @return A null ArraySlice.
+   * @note This cannot be called on a rvalue since the @c ArraySlice would
+   *   contain pointers to the size of the current @c SortedArrayView that is
+   *   about to be destroyed. This overload prevents that from happening.
+   */
+  LVARRAY_HOST_DEVICE constexpr inline
+  ArraySlice< T const, 1, 0, INDEX_TYPE > toSlice() const &&
+  {
+    static_assert( typeManipulation::always_true< T >, "Cannot call toSlice on an rvalue." );
+    return ArraySlice< T const, 1, 0, INDEX_TYPE >( nullptr, nullptr, nullptr );
+  }
 
   ///@}
 
@@ -200,6 +222,17 @@ public:
    */
   LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
   T const & operator[]( INDEX_TYPE const i ) const
+  {
+    SORTEDARRAY_CHECK_BOUNDS( i );
+    return data()[ i ];
+  }
+
+  /**
+   * @return Return the value at position @p i .
+   * @param i the index of the value to access.
+   */
+  LVARRAY_HOST_DEVICE CONSTEXPR_WITHOUT_BOUNDS_CHECK inline
+  T const & operator()( INDEX_TYPE const i ) const
   {
     SORTEDARRAY_CHECK_BOUNDS( i );
     return data()[ i ];

--- a/src/SortedArrayView.hpp
+++ b/src/SortedArrayView.hpp
@@ -138,7 +138,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE >
-  toView() const LVARRAY_RESTRICT_THIS
+  toView() const
   { return SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE >( size(), m_values ); }
 
   /**
@@ -146,7 +146,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   SortedArrayView< T const, INDEX_TYPE, BUFFER_TYPE >
-  toViewConst() const LVARRAY_RESTRICT_THIS
+  toViewConst() const
   { return toView(); }
 
   ///@}
@@ -241,7 +241,7 @@ public:
    *   to the GPU @p touch is set to false.
    */
   inline
-  void move( MemorySpace const space, bool touch=true ) const LVARRAY_RESTRICT_THIS
+  void move( MemorySpace const space, bool touch=true ) const
   {
   #if defined(LVARRAY_USE_CUDA)
     if( space == MemorySpace::GPU ) touch = false;

--- a/src/SparsityPatternView.hpp
+++ b/src/SparsityPatternView.hpp
@@ -85,6 +85,12 @@ public:
   ///@{
 
   /**
+   * @brief A constructor to create an uninitialized SparsityPatternView.
+   * @note An uninitialized SparsityPatternView should not be used until it is assigned to.
+   */
+  SparsityPatternView() = default;
+
+  /**
    * @brief Default copy constructor.
    * @note The copy constructor will trigger the copy constructor for @tparam BUFFER_TYPE
    */
@@ -153,7 +159,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   SparsityPatternView< COL_TYPE, INDEX_TYPE const, BUFFER_TYPE >
-  toView() const LVARRAY_RESTRICT_THIS
+  toView() const
   {
     return SparsityPatternView< COL_TYPE, INDEX_TYPE const, BUFFER_TYPE >( numRows(),
                                                                            numColumns(),
@@ -167,7 +173,7 @@ public:
    */
   LVARRAY_HOST_DEVICE constexpr inline
   SparsityPatternView< COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >
-  toViewConst() const LVARRAY_RESTRICT_THIS
+  toViewConst() const
   {
     return SparsityPatternView< COL_TYPE const, INDEX_TYPE const, BUFFER_TYPE >( numRows(),
                                                                                  numColumns(),
@@ -187,21 +193,21 @@ public:
    * @return Return the number of rows in the matrix.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  INDEX_TYPE_NC numRows() const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC numRows() const
   { return ParentClass::size(); }
 
   /**
    * @return Return the number of columns in the matrix.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  INDEX_TYPE_NC numColumns() const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC numColumns() const
   { return m_numCols; }
 
   /**
    * @return Return the total number of non zero entries in the matrix.
    */
   LVARRAY_HOST_DEVICE inline
-  INDEX_TYPE_NC numNonZeros() const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC numNonZeros() const
   {
     INDEX_TYPE_NC nnz = 0;
     for( INDEX_TYPE_NC row = 0; row < numRows(); ++row )
@@ -217,14 +223,14 @@ public:
    * @param row the row to query.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  INDEX_TYPE_NC numNonZeros( INDEX_TYPE const row ) const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC numNonZeros( INDEX_TYPE const row ) const
   { return ParentClass::sizeOfSet( row ); }
 
   /**
    * @return Return the total number of non zero entries able to be stored without a reallocation.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  INDEX_TYPE_NC nonZeroCapacity() const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC nonZeroCapacity() const
   { return ParentClass::valueCapacity(); }
 
   /**
@@ -233,14 +239,14 @@ public:
    * @param row the row to query.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  INDEX_TYPE_NC nonZeroCapacity( INDEX_TYPE const row ) const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC nonZeroCapacity( INDEX_TYPE const row ) const
   { return ParentClass::capacityOfSet( row ); }
 
   /**
    * @return Return true iff the matrix is all zeros.
    */
   LVARRAY_HOST_DEVICE inline
-  bool empty() const LVARRAY_RESTRICT_THIS
+  bool empty() const
   { return numNonZeros() == 0; }
 
   /**
@@ -248,7 +254,7 @@ public:
    * @param row the row to query.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  bool empty( INDEX_TYPE const row ) const LVARRAY_RESTRICT_THIS
+  bool empty( INDEX_TYPE const row ) const
   { return numNonZeros( row ) == 0; }
 
   /**
@@ -257,7 +263,7 @@ public:
    * @param col the col to query.
    */
   LVARRAY_HOST_DEVICE inline
-  bool empty( INDEX_TYPE const row, COL_TYPE const col ) const LVARRAY_RESTRICT_THIS
+  bool empty( INDEX_TYPE const row, COL_TYPE const col ) const
   { return !ParentClass::contains( row, col ); }
 
   ///@}
@@ -272,14 +278,14 @@ public:
    * @param row the row to access.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  ArraySlice< COL_TYPE const, 1, 0, INDEX_TYPE_NC >getColumns( INDEX_TYPE const row ) const LVARRAY_RESTRICT_THIS
+  ArraySlice< COL_TYPE const, 1, 0, INDEX_TYPE_NC >getColumns( INDEX_TYPE const row ) const
   { return (*this)[row]; }
 
   /**
    * @return Return a pointer to the array of offsets, this array has length numRows() + 1.
    */
   LVARRAY_HOST_DEVICE constexpr inline
-  INDEX_TYPE const * getOffsets() const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE const * getOffsets() const
   { return this->m_offsets.data(); }
 
   ///@}
@@ -298,7 +304,7 @@ public:
    *       up to the user to ensure that the given row has enough space for the new entries.
    */
   LVARRAY_HOST_DEVICE inline
-  bool insertNonZero( INDEX_TYPE const row, COL_TYPE const col ) const LVARRAY_RESTRICT_THIS
+  bool insertNonZero( INDEX_TYPE const row, COL_TYPE const col ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( row );
     SPARSITYPATTERN_COLUMN_CHECK( col );
@@ -318,7 +324,7 @@ public:
    */
   template< typename ITER >
   LVARRAY_HOST_DEVICE inline
-  INDEX_TYPE_NC insertNonZeros( INDEX_TYPE const row, ITER const first, ITER const last ) const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC insertNonZeros( INDEX_TYPE const row, ITER const first, ITER const last ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( row );
 
@@ -337,7 +343,7 @@ public:
    * @return True iff the column was removed (the entry was non zero before).
    */
   LVARRAY_HOST_DEVICE inline
-  bool removeNonZero( INDEX_TYPE const row, COL_TYPE const col ) const LVARRAY_RESTRICT_THIS
+  bool removeNonZero( INDEX_TYPE const row, COL_TYPE const col ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( row );
     SPARSITYPATTERN_COLUMN_CHECK( col );
@@ -356,7 +362,7 @@ public:
   DISABLE_HD_WARNING
   template< typename ITER >
   LVARRAY_HOST_DEVICE inline
-  INDEX_TYPE_NC removeNonZeros( INDEX_TYPE const row, ITER const first, ITER const last ) const LVARRAY_RESTRICT_THIS
+  INDEX_TYPE_NC removeNonZeros( INDEX_TYPE const row, ITER const first, ITER const last ) const
   {
     ARRAYOFARRAYS_CHECK_BOUNDS( row );
 
@@ -389,11 +395,12 @@ public:
 protected:
 
   /**
-   * @brief Default constructor.
-   * @note Protected since every SparsityPatternView should either be the base of a
-   *   SparsityPattern or copied from another SparsityPatternView.
+   * @brief Protected constructor to be used by parent classes.
+   * @note The unused boolean parameter is to distinguish this from the default constructor.
    */
-  SparsityPatternView() = default;
+  SparsityPatternView( bool ):
+    ParentClass( true )
+  {};
 
   /**
    * @brief Steal the resources of @p src, clearing it in the process.

--- a/src/SparsityPatternView.hpp
+++ b/src/SparsityPatternView.hpp
@@ -407,7 +407,10 @@ protected:
    * @param src The SparsityPatternView to steal from.
    */
   void assimilate( SparsityPatternView && src )
-  { *this = std::move( src ); }
+  {
+    ParentClass::free();
+    *this = std::move( src );
+  }
 
   /**
    * @tparam BUFFERS A variadic pack of buffer types.

--- a/src/sortedArrayManipulation.hpp
+++ b/src/sortedArrayManipulation.hpp
@@ -81,7 +81,7 @@ public:
    */
   LVARRAY_HOST_DEVICE inline
   T * incrementSize( T * const curPtr,
-                     std::ptrdiff_t const nToAdd ) LVARRAY_RESTRICT_THIS
+                     std::ptrdiff_t const nToAdd )
   {
     LVARRAY_UNUSED_VARIABLE( nToAdd );
     return curPtr;
@@ -92,7 +92,7 @@ public:
    * @param pos the position the value was inserted at.
    */
   LVARRAY_HOST_DEVICE inline
-  void insert( std::ptrdiff_t const pos ) LVARRAY_RESTRICT_THIS
+  void insert( std::ptrdiff_t const pos )
   { LVARRAY_UNUSED_VARIABLE( pos ); }
 
   /**
@@ -103,7 +103,7 @@ public:
    */
   LVARRAY_HOST_DEVICE inline
   void set( std::ptrdiff_t const pos,
-            std::ptrdiff_t const valuePos ) LVARRAY_RESTRICT_THIS
+            std::ptrdiff_t const valuePos )
   {
     LVARRAY_UNUSED_VARIABLE( pos );
     LVARRAY_UNUSED_VARIABLE( valuePos );
@@ -122,7 +122,7 @@ public:
   void insert( std::ptrdiff_t const nLeftToInsert,
                std::ptrdiff_t const valuePos,
                std::ptrdiff_t const pos,
-               std::ptrdiff_t const prevPos ) LVARRAY_RESTRICT_THIS
+               std::ptrdiff_t const prevPos )
   {
     LVARRAY_UNUSED_VARIABLE( nLeftToInsert );
     LVARRAY_UNUSED_VARIABLE( valuePos );
@@ -135,7 +135,7 @@ public:
    * @param pos The position of the entry that was removed.
    */
   LVARRAY_HOST_DEVICE inline
-  void remove( std::ptrdiff_t const pos ) LVARRAY_RESTRICT_THIS
+  void remove( std::ptrdiff_t const pos )
   { LVARRAY_UNUSED_VARIABLE( pos ); }
 
   /**
@@ -149,7 +149,7 @@ public:
   LVARRAY_HOST_DEVICE inline
   void remove( std::ptrdiff_t const nRemoved,
                std::ptrdiff_t const curPos,
-               std::ptrdiff_t const nextPos ) LVARRAY_RESTRICT_THIS
+               std::ptrdiff_t const nextPos )
   {
     LVARRAY_UNUSED_VARIABLE( nRemoved );
     LVARRAY_UNUSED_VARIABLE( curPos );
@@ -172,7 +172,7 @@ struct less
    */
   DISABLE_HD_WARNING
   constexpr LVARRAY_HOST_DEVICE inline
-  bool operator() ( T const & lhs, T const & rhs ) const LVARRAY_RESTRICT_THIS
+  bool operator() ( T const & lhs, T const & rhs ) const
   { return lhs < rhs; }
 };
 
@@ -191,7 +191,7 @@ struct greater
    */
   DISABLE_HD_WARNING
   constexpr LVARRAY_HOST_DEVICE inline
-  bool operator() ( T const & lhs, T const & rhs ) const LVARRAY_RESTRICT_THIS
+  bool operator() ( T const & lhs, T const & rhs ) const
   { return lhs > rhs; }
 };
 

--- a/src/sortedArrayManipulationHelpers.hpp
+++ b/src/sortedArrayManipulationHelpers.hpp
@@ -139,7 +139,7 @@ struct DualIteratorAccessor
    * @return *this.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE inline DualIteratorAccessor & operator=( DualIteratorAccessor && src ) LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline DualIteratorAccessor & operator=( DualIteratorAccessor && src )
   {
     m_a = std::move( src.m_a );
     m_b = std::move( src.m_b );
@@ -152,7 +152,7 @@ struct DualIteratorAccessor
    * @return *this.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE DualIteratorAccessor & operator=( Temporary && src ) LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE DualIteratorAccessor & operator=( Temporary && src )
   {
     m_a = std::move( src.m_a );
     m_b = std::move( src.m_b );
@@ -194,7 +194,7 @@ struct DualIteratorComparator
    */
   DISABLE_HD_WARNING
   LVARRAY_HOST_DEVICE inline bool operator()( DualIteratorAccessor< A, B > const & lhs,
-                                              DualIteratorAccessor< A, B > const & rhs ) const LVARRAY_RESTRICT_THIS
+                                              DualIteratorAccessor< A, B > const & rhs ) const
   { return m_compare( lhs.m_a, rhs.m_a ); }
 
   /**
@@ -205,7 +205,7 @@ struct DualIteratorComparator
    */
   DISABLE_HD_WARNING
   LVARRAY_HOST_DEVICE inline bool operator()( typename DualIteratorAccessor< A, B >::Temporary const & lhs,
-                                              DualIteratorAccessor< A, B > const & rhs ) const LVARRAY_RESTRICT_THIS
+                                              DualIteratorAccessor< A, B > const & rhs ) const
   { return m_compare( lhs.m_a, rhs.m_a ); }
 
 private:
@@ -282,7 +282,7 @@ public:
    * @return A new DualIterator where both of the underlying iterators have been incremented by offset.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE inline DualIterator operator+( std::ptrdiff_t const offset ) const LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline DualIterator operator+( std::ptrdiff_t const offset ) const
   { return DualIterator( m_itA + offset, m_itB + offset ); }
 
   /**
@@ -291,7 +291,7 @@ public:
    * @return *this.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE inline DualIterator & operator+=( std::ptrdiff_t const offset ) LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline DualIterator & operator+=( std::ptrdiff_t const offset )
   {
     m_itA += offset;
     m_itB += offset;
@@ -303,7 +303,7 @@ public:
    * @return *this.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE inline DualIterator & operator++() LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline DualIterator & operator++()
   {
     m_itA++;
     m_itB++;
@@ -316,7 +316,7 @@ public:
    * @return The distance between *this and the @p rhs.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE inline std::ptrdiff_t operator-( DualIterator const & rhs ) const LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline std::ptrdiff_t operator-( DualIterator const & rhs ) const
   {
     std::ptrdiff_t const distance = m_itA - rhs.m_itA;
     LVARRAY_ASSERT_EQ( distance, m_itB - rhs.m_itB );
@@ -329,7 +329,7 @@ public:
    * @return A new DualIterator where both of the underlying iterators have been decrement by @p offset.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE inline DualIterator operator-( std::ptrdiff_t const offset ) const LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline DualIterator operator-( std::ptrdiff_t const offset ) const
   { return *this + (-offset); }
 
   /**
@@ -338,7 +338,7 @@ public:
    * @return *this.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE inline DualIterator & operator-=( std::ptrdiff_t const offset ) LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline DualIterator & operator-=( std::ptrdiff_t const offset )
   { return *this += (-offset); }
 
   /**
@@ -346,7 +346,7 @@ public:
    * @return *this.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE inline DualIterator & operator--() LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline DualIterator & operator--()
   {
     m_itA--;
     m_itB--;
@@ -359,7 +359,7 @@ public:
    * @return True if @p rhs does not point to the same values.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE inline bool operator!=( DualIterator const & rhs ) const LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline bool operator!=( DualIterator const & rhs ) const
   { return m_itA != rhs.m_itA; }
 
   /**
@@ -368,7 +368,7 @@ public:
    * @return True if this less than @p rhs.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE inline bool operator<( DualIterator const & rhs ) const LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline bool operator<( DualIterator const & rhs ) const
   { return m_itA < rhs.m_itA; }
 
   /**
@@ -376,7 +376,7 @@ public:
    * @return A DualIteratorAccessor to the two values at which m_itA and m_itB point at.
    */
   DISABLE_HD_WARNING
-  LVARRAY_HOST_DEVICE inline DualIteratorAccessor< A, B > operator*() const LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline DualIteratorAccessor< A, B > operator*() const
   { return DualIteratorAccessor< A, B >( *m_itA, *m_itB ); }
 
   /**
@@ -387,7 +387,7 @@ public:
    */
   DISABLE_HD_WARNING
   template< class Compare >
-  LVARRAY_HOST_DEVICE inline DualIteratorComparator< A, B, Compare > createComparator( Compare && comp ) const LVARRAY_RESTRICT_THIS
+  LVARRAY_HOST_DEVICE inline DualIteratorComparator< A, B, Compare > createComparator( Compare && comp ) const
   { return DualIteratorComparator< A, B, Compare >( std::forward< Compare >( comp ) ); }
 
 private:

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -432,6 +432,7 @@ static void ibmAbort()
 
 std::function< void() > s_errorHandler = ibmAbort;
 #else
+/// The error handler to use.
 std::function< void() > s_errorHandler = std::abort;
 #endif
 

--- a/src/typeManipulation.hpp
+++ b/src/typeManipulation.hpp
@@ -126,6 +126,14 @@ template< bool ... BOOLS >
 using all_of = camp::concepts::metalib::all_of< BOOLS ... >;
 
 /**
+ * @brief A template boolean that is always true.
+ * @note This is intended for use in @c static_assert where some template dependence is necessary
+ *   to only generate the assert when the function or method is actually instantiated.
+ */
+template< typename T >
+constexpr bool always_true = true;
+
+/**
  * @brief A struct that contains a static constexpr bool value that is true if all of TYPES::value are true.
  * @tparam TYPES A variadic pack of types all of which define a static constexpr bool value.
  * @note Not a static constexpr bool so it can be used on device.
@@ -270,6 +278,11 @@ struct GetViewTypeConst< T, true >
   using type = decltype( std::declval< T >().toViewConst() );
 };
 
+/**
+ * @struct GetNestedViewType
+ * @brief A helper struct used to get the nested view type of an object.
+ * @tparam T The type to get the nested view type of.
+ */
 template< typename T, bool=HasMemberFunction_toNestedView< T > >
 struct GetNestedViewType
 {
@@ -277,7 +290,12 @@ struct GetNestedViewType
   using type = typename GetViewType< T >::type;
 };
 
-
+/**
+ * @struct GetNestedViewType< T, true >
+ * @brief A helper struct used to get the nested view type of an object.
+ * @tparam T The type to get the nested view type of.
+ * @note This is a specialization for objects with a toNestedView method.
+ */
 template< typename T >
 struct GetNestedViewType< T, true >
 {
@@ -285,6 +303,11 @@ struct GetNestedViewType< T, true >
   using type = decltype( std::declval< T >().toNestedView() ) const;
 };
 
+/**
+ * @struct GetNestedViewTypeConst
+ * @brief A helper struct used to get the nested view const type of an object.
+ * @tparam T The type to get the nested view const type of.
+ */
 template< typename T, bool=HasMemberFunction_toNestedViewConst< T > >
 struct GetNestedViewTypeConst
 {
@@ -292,7 +315,12 @@ struct GetNestedViewTypeConst
   using type = typename GetViewTypeConst< T >::type;
 };
 
-
+/**
+ * @struct GetNestedViewTypeConst< T, true >
+ * @brief A helper struct used to get the nested view const type of an object.
+ * @tparam T The type to get the nested view const type of.
+ * @note This is a specialization for objects with a toNestedViewConst method.
+ */
 template< typename T >
 struct GetNestedViewTypeConst< T, true >
 {

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -62,6 +62,7 @@ set(testSources
     testTensorOpsSymInverseTwoArgs.cpp
     testTypeManipulation.cpp
     testStackTrace.cpp
+    testInvalidOperations.cpp
    )
 
 #

--- a/unitTests/testArray.hpp
+++ b/unitTests/testArray.hpp
@@ -9,7 +9,6 @@
 #include "Array.hpp"
 #include "output.hpp"
 #include "testUtils.hpp"
-#include "MallocBuffer.hpp"
 
 // TPL includes
 #include <gtest/gtest.h>

--- a/unitTests/testInvalidOperations.cpp
+++ b/unitTests/testInvalidOperations.cpp
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC and LvArray contributors.
+ * All rights reserved.
+ * See the LICENSE file for details.
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
+
+// Source includes
+#include "Array.hpp"
+#include "SortedArray.hpp"
+#include "ArrayOfArrays.hpp"
+#include "ArrayOfSets.hpp"
+#include "SparsityPattern.hpp"
+#include "CRSMatrix.hpp"
+#include "testUtils.hpp"
+
+// TPL includes
+#include <gtest/gtest.h>
+
+/*
+ * When ALLOW_INVALID_OPERATIONS is defined each of the tests below should have a compilation error from
+ * attempting to perform an operation forbidden by LvArray.
+ */
+// #define ALLOW_INVALID_OPERATIONS
+
+namespace LvArray
+{
+namespace testing
+{
+
+TEST( Array, toView )
+{
+  Array< int, 1, RAJA::PERM_I, std::ptrdiff_t, MallocBuffer > array;
+  auto const view = array.toView();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( array ).toView();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( Array, toViewConst )
+{
+  Array< int, 1, RAJA::PERM_I, std::ptrdiff_t, MallocBuffer > array;
+  auto const view = array.toViewConst();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( array ).toViewConst();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( Array, toNestedView )
+{
+  Array< int, 1, RAJA::PERM_I, std::ptrdiff_t, MallocBuffer > array;
+  auto const & view = array.toNestedView();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const & invalidView = std::move( array ).toNestedView();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( Array, toNestedViewConst )
+{
+  Array< int, 1, RAJA::PERM_I, std::ptrdiff_t, MallocBuffer > array;
+  auto const & view = array.toNestedViewConst();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const & invalidView = std::move( array ).toNestedViewConst();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( Array, toViewConstUDC )
+{
+  Array< int, 1, RAJA::PERM_I, std::ptrdiff_t, MallocBuffer > array;
+  ArrayView< int const, 1, 0, std::ptrdiff_t, MallocBuffer > const view = array;
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  ArrayView< int const, 1, 0, std::ptrdiff_t, MallocBuffer > const invalidView = std::move( array );
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( Array, accessOperator )
+{
+  Array< int, 2, RAJA::PERM_IJ, std::ptrdiff_t, MallocBuffer > array( 5, 5 );
+  auto const slice = array[ 0 ];
+  LVARRAY_UNUSED_VARIABLE( slice );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidSlice = std::move( array )[ 0 ];
+  LVARRAY_UNUSED_VARIABLE( invalidSlice );
+#endif
+}
+
+TEST( ArrayView, toSlice )
+{
+  ArrayView< int, 1, 0, std::ptrdiff_t, MallocBuffer > view;
+  auto const slice = view.toSlice();
+  LVARRAY_UNUSED_VARIABLE( slice );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidSlice = std::move( view ).toSlice();
+  LVARRAY_UNUSED_VARIABLE( invalidSlice );
+#endif
+}
+
+TEST( ArrayView, toSliceConst )
+{
+  ArrayView< int, 1, 0, std::ptrdiff_t, MallocBuffer > view;
+  auto const slice = view.toSliceConst();
+  LVARRAY_UNUSED_VARIABLE( slice );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidSlice = std::move( view ).toSliceConst();
+  LVARRAY_UNUSED_VARIABLE( invalidSlice );
+#endif
+}
+
+TEST( ArrayView, toSliceUDC )
+{
+  ArrayView< int, 1, 0, std::ptrdiff_t, MallocBuffer > view;
+  ArraySlice< int, 1, 0, std::ptrdiff_t > const slice = view;
+  LVARRAY_UNUSED_VARIABLE( slice );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  ArraySlice< int, 1, 0, std::ptrdiff_t > const invalidSlice = std::move( view );
+  LVARRAY_UNUSED_VARIABLE( invalidSlice );
+#endif
+}
+
+TEST( ArrayView, toSliceConstUDC )
+{
+  ArrayView< int, 1, 0, std::ptrdiff_t, MallocBuffer > view;
+  ArraySlice< int const, 1, 0, std::ptrdiff_t > const slice = view;
+  LVARRAY_UNUSED_VARIABLE( slice );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  ArraySlice< int const, 1, 0, std::ptrdiff_t > const invalidSlice = std::move( view );
+  LVARRAY_UNUSED_VARIABLE( invalidSlice );
+#endif
+}
+
+TEST( SortedArray, toView )
+{
+  SortedArray< int, std::ptrdiff_t, MallocBuffer > array;
+  auto const view = array.toView();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( array ).toView();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( SortedArray, toViewConst )
+{
+  SortedArray< int, std::ptrdiff_t, MallocBuffer > array;
+  auto const view = array.toViewConst();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( array ).toViewConst();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( ArrayOfArrays, toView )
+{
+  ArrayOfArrays< int, std::ptrdiff_t, MallocBuffer > array;
+  auto const view = array.toView();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( array ).toView();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( ArrayOfArrays, toViewConstSizes )
+{
+  ArrayOfArrays< int, std::ptrdiff_t, MallocBuffer > array;
+  auto const view = array.toViewConstSizes();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( array ).toViewConstSizes();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( ArrayOfArrays, toViewConst )
+{
+  ArrayOfArrays< int, std::ptrdiff_t, MallocBuffer > array;
+  auto const view = array.toViewConst();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( array ).toViewConst();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( ArrayOfSets, toView )
+{
+  ArrayOfSets< int, std::ptrdiff_t, MallocBuffer > array;
+  auto const view = array.toView();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( array ).toView();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( ArrayOfSets, toViewConst )
+{
+  ArrayOfSets< int, std::ptrdiff_t, MallocBuffer > array;
+  auto const view = array.toViewConst();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( array ).toViewConst();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( ArrayOfSets, toArrayOfArraysView )
+{
+  ArrayOfSets< int, std::ptrdiff_t, MallocBuffer > array;
+  auto const view = array.toArrayOfArraysView();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( array ).toArrayOfArraysView();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( SparsityPattern, toView )
+{
+  SparsityPattern< int, std::ptrdiff_t, MallocBuffer > sparsity;
+  auto const view = sparsity.toView();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( sparsity ).toView();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( SparsityPattern, toViewConst )
+{
+  SparsityPattern< int, std::ptrdiff_t, MallocBuffer > sparsity;
+  auto const view = sparsity.toViewConst();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( sparsity ).toViewConst();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( CRSMatrix, toView )
+{
+  CRSMatrix< int, int, std::ptrdiff_t, MallocBuffer > matrix;
+  auto const view = matrix.toView();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( matrix ).toView();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( CRSMatrix, toViewConstSizes )
+{
+  CRSMatrix< int, int, std::ptrdiff_t, MallocBuffer > matrix;
+  auto const view = matrix.toViewConstSizes();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( matrix ).toViewConstSizes();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( CRSMatrix, toViewConst )
+{
+  CRSMatrix< int, int, std::ptrdiff_t, MallocBuffer > matrix;
+  auto const view = matrix.toViewConst();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( matrix ).toViewConst();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+TEST( CRSMatrix, toSparsityPatternView )
+{
+  CRSMatrix< int, int, std::ptrdiff_t, MallocBuffer > matrix;
+  auto const view = matrix.toSparsityPatternView();
+  LVARRAY_UNUSED_VARIABLE( view );
+
+#if defined(ALLOW_INVALID_OPERATIONS)
+  auto const invalidView = std::move( matrix ).toSparsityPatternView();
+  LVARRAY_UNUSED_VARIABLE( invalidView );
+  FAIL();
+#endif
+}
+
+} // namespace testing
+} // namespace LvArray
+
+// This is the default gtest main method. It is included for ease of debugging.
+int main( int argc, char * * argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  int const result = RUN_ALL_TESTS();
+  return result;
+}

--- a/unitTests/testSortedArray.cpp
+++ b/unitTests/testSortedArray.cpp
@@ -39,22 +39,34 @@ public:
    */
   void compareToReference() const
   {
-    ASSERT_EQ( m_set.size(), m_ref.size() );
-    ASSERT_EQ( m_set.empty(), m_ref.empty() );
+    EXPECT_EQ( m_set.size(), m_ref.size() );
+    EXPECT_EQ( m_set.empty(), m_ref.empty() );
     if( m_set.empty() )
     {
-      ASSERT_EQ( m_set.size(), 0 );
+      EXPECT_EQ( m_set.size(), 0 );
       return;
     }
 
     T const * ptr = m_set.data();
+    ArraySlice< T const, 1, 0, INDEX_TYPE > const slice = m_set.toSlice();
     typename std::set< T >::const_iterator it = m_ref.begin();
     for( int i = 0; i < m_set.size(); ++i )
     {
-      ASSERT_EQ( m_set[ i ], *it );
-      ASSERT_EQ( ptr[ i ], *it );
+      EXPECT_EQ( m_set[ i ], *it );
+      EXPECT_EQ( m_set( i ), *it );
+      EXPECT_EQ( ptr[ i ], *it );
+      EXPECT_EQ( slice[ i ], *it );
       ++it;
     }
+
+    it = m_ref.begin();
+    for( T const & val : m_set )
+    {
+      EXPECT_EQ( val, *it );
+      ++it;
+    }
+
+    EXPECT_EQ( it, m_ref.end() );
   }
 
   #define COMPARE_TO_REFERENCE { SCOPED_TRACE( "" ); compareToReference(); \


### PR DESCRIPTION
Protects against a bunch of rvalue bugs. Not everything is protected though, for example you can still call `data` on an `Array &&`.

Closes #197, closes #168.

Related to https://github.com/GEOSX/GEOSX/pull/1216