### PR TITLE
Fixed memory leaks in CRSMatrix::assimilate and ArrayOfArrays::free with non trivial data.

### DIFF
--- a/src/ArrayOfArraysView.hpp
+++ b/src/ArrayOfArraysView.hpp
@@ -957,7 +957,7 @@ private:
 
     typeManipulation::forEachArg( [this, begin, end] ( auto & buffer )
     {
-      if( !std::is_trivially_destructible< decltype( buffer[ 0 ] ) >::value )
+      if( !std::is_trivially_destructible< std::remove_reference_t< decltype( buffer[ 0 ] ) > >::value )
       {
         buffer.move( MemorySpace::CPU, true );
         for( INDEX_TYPE i = begin; i < end; ++i )

--- a/src/SparsityPatternView.hpp
+++ b/src/SparsityPatternView.hpp
@@ -400,7 +400,10 @@ protected:
    * @param src The SparsityPatternView to steal from.
    */
   void assimilate( SparsityPatternView && src )
-  { *this = std::move( src ); }
+  {
+    ParentClass::free();
+    *this = std::move( src );
+  }
 
   /**
    * @tparam BUFFERS A variadic pack of buffer types.


### PR DESCRIPTION
Won't be merged, the changes are in https://github.com/GEOSX/LvArray/pull/211.