### PR TITLE
LC GitLab integration.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,56 @@
+###############################################################################
+# General GitLab pipelines configurations for supercomputers and Linux clusters
+# at Lawrence Livermore National Laboratory (LLNL).
+#
+# This entire pipeline is LLNL-specific
+###############################################################################
+
+# We define the following GitLab pipeline variables:
+#
+# GIT_SUBMODULE_STRATEGY:
+# Tells Gitlab to recursively update the submodules when cloning LvArray
+#
+# ALLOC_NAME:
+# On LLNL's quartz, this pipeline creates only one allocation shared among jobs
+# in order to save time and resources. This allocation has to be uniquely named
+# so that we are able to retrieve it.
+variables:
+  GIT_SUBMODULE_STRATEGY: recursive
+  ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
+
+# Normally, stages are blocking in Gitlab. However, using the keyword "needs" we
+# can express dependencies between job that break the ordering of stages, in
+# favor of a DAG.
+# In practice q_* and l_* stages are independently run and start immediately.
+stages:
+  - environment
+# quartz stages
+  - q_allocate_resources
+  - q_build_and_test
+  - q_release_resources
+# lassen stages
+  - l_build_and_test
+
+# These are also templates (.name) that define project specific build commands.
+# If an allocation exist with the name defined in this pipeline, the job will
+# use it (slurm specific).
+.build_toss_3_x86_64_ib_script:
+  script:
+    - echo ${ALLOC_NAME}
+    - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
+    - echo ${JOBID}
+    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 15 -N 1 scripts/gitlab/build_and_test.sh
+
+# Lassen uses a different job scheduler (spectrum lsf) that does not
+# allow pre-allocation the same way slurm does.
+.build_blueos_3_ppc64le_ib_p9_script:
+  script:
+    - lalloc 1 -W 15 scripts/gitlab/build_and_test.sh
+
+# "include" allows us to split the configuration in logical blocks
+include:
+  - template: 'Workflows/MergeRequest-Pipelines.gitlab-ci.yml'
+  - local: .gitlab/quartz-templates.yml
+  - local: .gitlab/quartz-jobs.yml
+  - local: .gitlab/lassen-templates.yml
+  - local: .gitlab/lassen-jobs.yml

--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -1,0 +1,13 @@
+lassen_clang_10_0_1:
+  variables:
+    NAME: lassen_clang_10_0_1
+    SPEC: "%clang@10.0.1 +cuda +umpire +chai +benchmarks +examples cuda_arch=70 ^cuda@10.1.243 ^raja@0.12.1 build_type=Release cuda_arch=70 ^umpire@4.1.2 build_type=Release cuda_arch=70 ^chai@2.2.0 build_type=Release cuda_arch=70"
+    BUILD_TYPE: "Debug Release"
+  extends: .build_and_test_on_lassen
+
+lassen_gcc_8_3_1:
+  variables:
+    NAME: lassen_gcc_8_3_1
+    SPEC: "%gcc@8.3.1 +cuda +umpire +chai +benchmarks +examples cuda_arch=70 ^cuda@10.1.243 ^raja@0.12.1 build_type=Release cuda_arch=70 ^umpire@4.1.2 build_type=Release cuda_arch=70 ^chai@2.2.0 build_type=Release cuda_arch=70"
+    BUILD_TYPE: "Debug Release"
+  extends: .build_and_test_on_lassen

--- a/.gitlab/lassen-templates.yml
+++ b/.gitlab/lassen-templates.yml
@@ -1,0 +1,16 @@
+####
+# Shared configuration of jobs for lassen
+.on_lassen:
+  variables:
+  tags:
+    - shell
+    - lassen
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /_lnone/ || $ON_LASSEN == "OFF"'
+      when: never
+    - when: on_success
+
+.build_and_test_on_lassen:
+  stage: l_build_and_test
+  extends: [.build_blueos_3_ppc64le_ib_p9_script, .on_lassen]
+  needs: []

--- a/.gitlab/quartz-jobs.yml
+++ b/.gitlab/quartz-jobs.yml
@@ -1,0 +1,13 @@
+quartz_clang_10_0_1:
+  variables:
+    NAME: quartz_clang_10_0_1
+    SPEC: "%clang@10.0.1 +umpire +chai +benchmarks +examples ^raja@0.12.1 build_type=Release ^umpire@4.1.2 build_type=Release ^chai@2.2.0 build_type=Release"
+    BUILD_TYPE: "Debug Release"
+  extends: .build_and_test_on_quartz
+
+quartz_gcc_8_3_1:
+  variables:
+    NAME: quartz_gcc_8_3_1
+    SPEC: "%gcc@8.3.1 +umpire +chai +benchmarks +examples ^raja@0.12.1 build_type=Release ^umpire@4.1.2 build_type=Release ^chai@2.2.0 build_type=Release"
+    BUILD_TYPE: "Debug Release"
+  extends: .build_and_test_on_quartz

--- a/.gitlab/quartz-templates.yml
+++ b/.gitlab/quartz-templates.yml
@@ -1,0 +1,41 @@
+####
+# Shared configuration of jobs for quartz
+.on_quartz:
+  tags:
+    - shell
+    - quartz
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"'
+      when: never
+    - if: '$CI_JOB_NAME =~ /release_resources/'
+      when: always
+    - when: on_success
+
+####
+# In pre-build phase, allocate a node for builds
+allocate_resources (on quartz):
+  variables:
+    GIT_STRATEGY: none
+  extends: .on_quartz
+  stage: q_allocate_resources
+  script:
+    - salloc -N 1 -c 36 -p pdebug -t 20 --no-shell --job-name=${ALLOC_NAME}
+
+####
+# In post-build phase, deallocate resources
+# Note : make sure this is run even on failure of the build phase
+# (see .on_quartz rules)
+release_resources (on quartz):
+  variables:
+    GIT_STRATEGY: none
+  extends: .on_quartz
+  stage: q_release_resources
+  script:
+    - export JOBID=$(squeue -h --name=${ALLOC_NAME} --format=%A)
+    - ([[ -n "${JOBID}" ]] && scancel ${JOBID})
+
+####
+# Generic quartz build job, extending build script
+.build_and_test_on_quartz:
+  extends: [.build_toss_3_x86_64_ib_script, .on_quartz]
+  stage: q_build_and_test

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-21, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+
+set -o errexit
+set -o nounset
+
+option=${1:-""}
+hostname="$(hostname)"
+project_dir="$(pwd)"
+
+hostconfig=${HOST_CONFIG:-""}
+
+name=${NAME}
+
+spec=${SPEC:-""}
+
+build_type=${BUILD_TYPE}
+
+# Dependencies
+if [[ "${option}" != "--build-only" && "${option}" != "--test-only" ]]
+then
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "~~~~~ Building Dependencies"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+    if [[ -z ${spec} ]]
+    then
+        echo "SPEC is undefined, aborting..."
+        exit 1
+    fi
+
+    prefix_opt=""
+
+    if [[ -d /dev/shm ]]
+    then
+        prefix="/dev/shm/${hostname}/${name}"
+        mkdir -p ${prefix}
+        prefix_opt="--prefix=${prefix}"
+    fi
+
+    python scripts/uberenv/uberenv.py --spec="${spec}" ${prefix_opt}
+fi
+
+# Host config file
+# We are looking for a unique host config in project dir.
+hostconfigs=( $( ls "${project_dir}/"*@*.cmake ) )
+if [[ ${#hostconfigs[@]} == 1 ]]
+then
+    hostconfig_path=${hostconfigs[0]}
+    echo "Found host config file: ${hostconfig_path}"
+elif [[ ${#hostconfigs[@]} == 0 ]]
+then
+    echo "No result for: ${project_dir}/hc-*.cmake"
+    echo "Spack generated host-config not found."
+    exit 1
+else
+    echo "More than one result for: ${project_dir}/hc-*.cmake"
+    echo "${hostconfigs[@]}"
+    echo "Please specify one with HOST_CONFIG variable"
+    exit 1
+fi
+
+
+build_dir="${project_dir}/build_"
+
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo "~~~~~ Project Dir: ${project_dir}"
+echo "~~~~~ Host-config: ${hostconfig_path}"
+echo "~~~~~ Build Dir:   ${build_dir}"
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+# Build
+for buildType in ${build_type}
+do
+    cd ${project_dir}
+
+    if [[ "${option}" != "--deps-only" && "${option}" != "--test-only" ]]
+    then
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        echo "~~~~~ Building LvArray"
+        echo "~~~~~ Build Type: ${buildType}"
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+        python scripts/config-build.py -hc ${hostconfig_path} -bt ${buildType} -bp ${build_dir}
+
+        cd ${build_dir}
+        cmake --build . -j
+    fi
+
+    # Test
+    if [[ "${option}" != "--build-only" ]]
+    then
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        echo "~~~~~ Testing LvArray"
+        echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+        if [[ ! -d ${build_dir} ]]
+        then
+            echo "ERROR: Build directory not found : ${build_dir}" && exit 1
+        fi
+
+        cd ${build_dir}
+
+        ctest --output-on-failure -T test 2>&1 | tee tests_output.txt
+
+        no_test_str="No tests were found!!!"
+        if [[ "$(tail -n 1 tests_output.txt)" == "${no_test_str}" ]]
+        then
+            echo "ERROR: No tests were found" && exit 1
+        fi
+
+        echo "Copying Testing xml reports for export"
+        tree Testing
+        cp Testing/*/Test.xml ${project_dir}
+
+        if grep -q "Errors while running CTest" ./tests_output.txt
+        then
+            echo "ERROR: failure(s) while running CTest" && exit 1
+        fi
+    fi
+done

--- a/scripts/uberenv/packages/chai/package.py
+++ b/scripts/uberenv/packages/chai/package.py
@@ -1,0 +1,74 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Chai(CMakePackage, CudaPackage):
+    """
+    Copy-hiding array interface for data migration between memory spaces
+    """
+
+    homepage = "https://github.com/LLNL/CHAI"
+    git      = "https://github.com/LLNL/CHAI.git"
+
+    version('develop', branch='develop', submodules='True')
+    version('master', branch='main', submodules='True')
+    version('2.2.0', tag='v2.2.0', submodules='True')
+    version('2.1.1', tag='v2.1.1', submodules='True')
+    version('2.1.0', tag='v2.1.0', submodules='True')
+    version('2.0.0', tag='v2.0.0', submodules='True')
+    version('1.2.0', tag='v1.2.0', submodules='True')
+    version('1.1.0', tag='v1.1.0', submodules='True')
+    version('1.0', tag='v1.0', submodules='True')
+
+    variant('shared', default=True, description='Build Shared Libs')
+    variant('raja', default=False, description='Build plugin for RAJA')
+    variant('benchmarks', default=False, description='Build benchmarks.')
+    variant('examples', default=False, description='Build examples.')
+
+    depends_on('cmake@3.8:', type='build')
+    depends_on('umpire')
+    depends_on('raja', when="+raja")
+
+    depends_on('cmake@3.9:', type='build', when="+cuda")
+    depends_on('umpire+cuda', when="+cuda")
+    depends_on('raja+cuda', when="+raja+cuda")
+
+    def cmake_args(self):
+        spec = self.spec
+
+        options = []
+
+        if '+cuda' in spec:
+            options.extend([
+                '-DENABLE_CUDA=ON',
+                '-DCUDA_TOOLKIT_ROOT_DIR=' + spec['cuda'].prefix])
+
+            if not spec.satisfies('cuda_arch=none'):
+                cuda_arch = spec.variants['cuda_arch'].value
+                options.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch[0]))
+                flag = '-arch sm_{0}'.format(cuda_arch[0])
+                options.append('-DCMAKE_CUDA_FLAGS:STRING={0}'.format(flag))
+        else:
+            options.append('-DENABLE_CUDA=OFF')
+
+        if '+raja' in spec:
+            options.extend(['-DENABLE_RAJA_PLUGIN=ON',
+                            '-DRAJA_DIR=' + spec['raja'].prefix])
+
+        options.append('-Dumpire_DIR:PATH='
+                       + spec['umpire'].prefix.share.umpire.cmake)
+
+        options.append('-DENABLE_TESTS={0}'.format(
+            'ON' if self.run_tests else 'OFF'))
+
+        options.append('-DENABLE_BENCHMARKS={0}'.format(
+            'ON' if '+benchmarks' in spec else 'OFF'))
+
+        options.append('-DENABLE_EXAMPLES={0}'.format(
+            'ON' if '+examples' in spec else 'OFF'))
+
+        return options

--- a/scripts/uberenv/packages/umpire/package.py
+++ b/scripts/uberenv/packages/umpire/package.py
@@ -1,0 +1,108 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class Umpire(CMakePackage, CudaPackage):
+    """An application-focused API for memory management on NUMA & GPU
+    architectures"""
+
+    homepage = 'https://github.com/LLNL/Umpire'
+    git      = 'https://github.com/LLNL/Umpire.git'
+
+    version('develop', branch='develop', submodules='True')
+    version('main', branch='main', submodules='True')
+    version('4.1.2', tag='v4.1.2', submodules='True')
+    version('4.1.1', tag='v4.1.1', submodules='True')
+    version('4.1.0', tag='v4.1.0', submodules='True')
+    version('4.0.1', tag='v4.0.1', submodules='True')
+    version('4.0.0', tag='v4.0.0', submodules='True')
+    version('3.0.0', tag='v3.0.0', submodules='True')
+    version('2.1.0', tag='v2.1.0', submodules='True')
+    version('2.0.0', tag='v2.0.0', submodules='True')
+    version('1.1.0', tag='v1.1.0', submodules='True')
+    version('1.0.1', tag='v1.0.1', submodules='True')
+    version('1.0.0', tag='v1.0.0', submodules='True')
+    version('0.3.5', tag='v0.3.5', submodules='True')
+    version('0.3.4', tag='v0.3.4', submodules='True')
+    version('0.3.3', tag='v0.3.3', submodules='True')
+    version('0.3.2', tag='v0.3.2', submodules='True')
+    version('0.3.1', tag='v0.3.1', submodules='True')
+    version('0.3.0', tag='v0.3.0', submodules='True')
+    version('0.2.4', tag='v0.2.4', submodules='True')
+    version('0.2.3', tag='v0.2.3', submodules='True')
+    version('0.2.2', tag='v0.2.2', submodules='True')
+    version('0.2.1', tag='v0.2.1', submodules='True')
+    version('0.2.0', tag='v0.2.0', submodules='True')
+    version('0.1.4', tag='v0.1.4', submodules='True')
+    version('0.1.3', tag='v0.1.3', submodules='True')
+
+    patch('camp_target_umpire_3.0.0.patch', when='@3.0.0')
+
+    variant('fortran', default=False, description='Build C/Fortran API')
+    variant('c', default=True, description='Build C API')
+    variant('numa', default=False, description='Enable NUMA support')
+    variant('shared', default=True, description='Enable Shared libs')
+    variant('openmp', default=False, description='Build with OpenMP support')
+    variant('deviceconst', default=False,
+            description='Enables support for constant device memory')
+    variant('examples', default=False, description='Build Umpire Examples')
+    variant('tests', default='none', values=('none', 'basic', 'benchmarks'),
+            multi=False, description='Tests to run')
+
+    depends_on('cmake@3.8:', type='build')
+    depends_on('cmake@3.9:', when='+cuda', type='build')
+
+    conflicts('+numa', when='@:0.3.2')
+    conflicts('~c', when='+fortran', msg='Fortran API requires C API')
+
+    def cmake_args(self):
+        spec = self.spec
+
+        options = []
+
+        if '+cuda' in spec:
+            options.extend([
+                '-DENABLE_CUDA=On',
+                '-DCUDA_TOOLKIT_ROOT_DIR=%s' % (spec['cuda'].prefix)])
+
+            if not spec.satisfies('cuda_arch=none'):
+                cuda_arch = spec.variants['cuda_arch'].value
+                options.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch[0]))
+                flag = '-arch sm_{0}'.format(cuda_arch[0])
+                options.append('-DCMAKE_CUDA_FLAGS:STRING={0}'.format(flag))
+
+            if '+deviceconst' in spec:
+                options.append('-DENABLE_DEVICE_CONST=On')
+        else:
+            options.append('-DENABLE_CUDA=Off')
+
+        options.append('-DENABLE_C={0}'.format(
+            'On' if '+c' in spec else 'Off'))
+
+        options.append('-DENABLE_FORTRAN={0}'.format(
+            'On' if '+fortran' in spec else 'Off'))
+
+        options.append('-DENABLE_NUMA={0}'.format(
+            'On' if '+numa' in spec else 'Off'))
+
+        options.append('-DENABLE_OPENMP={0}'.format(
+            'On' if '+openmp' in spec else 'Off'))
+
+        options.append('-DBUILD_SHARED_LIBS={0}'.format(
+            'On' if '+shared' in spec else 'Off'))
+
+        options.append('-DENABLE_BENCHMARKS={0}'.format(
+            'On' if 'tests=benchmarks' in spec else 'Off'))
+
+        options.append('-DENABLE_EXAMPLES={0}'.format(
+            'On' if '+examples' in spec else 'Off'))
+
+        options.append('-DENABLE_TESTS={0}'.format(
+            'Off' if 'tests=none' in spec else 'On'))
+
+        return options

--- a/scripts/uberenv/project.json
+++ b/scripts/uberenv/project.json
@@ -4,7 +4,7 @@
   "package_final_phase" : "hostconfig",
   "package_source_dir" : "../..",
   "spack_url": "https://github.com/corbett5/spack",
-  "spack_branch": "feature/corbett/lvarray",
+  "spack_branch": "package/corbett/geosx",
   "spack_activate" : {},
   "spack_clean_packages": ["lvarray"],
   "build_jobs": 100


### PR DESCRIPTION
This adds a LC GitLab CI that builds the TPL's via spack and then builds and tests LvArray for all eight combinations of debug/release, gcc/clang and quartz/lassen. Ideally it would also run the benchmarks for release builds and log the results. As is there are a few problems.

Problems:
- The CI is triggered manually by someone from the LLNL organization with 2FA enabled commenting "LGTM" on the PR. This triggers a run on the most recent commit.
- Even after commenting it can take some time for the GitLab mirror to pick up the changes and run the tests up to 30 minutes.
- You can only view the detailed results if you have an LC account.